### PR TITLE
fix(APP-3626): Update ProposalVoting Container/Stage components to correctly update on stage and status changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Update `ProposalVoting.Container` module component to make stages accordion controlled and support updating the
+    current active stage programmatically
+
 ### Changed
 
 -   Bump `softprops/action-gh-release` from 2.0.8 to 2.0.9

--- a/src/modules/components/proposal/proposalVoting/proposalVoting.stories.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVoting.stories.tsx
@@ -111,10 +111,11 @@ export const MultiStage: Story = {
         title: 'Voting',
         description:
             'The proposal must pass all governance stages to be accepted and potential onchain actions to execute.',
-        activeStage: '0',
         className: 'max-w-[560px]',
     },
     render: (args) => {
+        const [activeStage, setActiveStage] = useState<string | undefined>('0');
+
         const [tokenSearch, setTokenSearch] = useState<string | undefined>('');
         const [multisigSearch, setMultisigSearch] = useState<string | undefined>('');
 
@@ -122,7 +123,7 @@ export const MultiStage: Story = {
         const minApprovals = 4;
 
         return (
-            <ProposalVoting.Container {...args}>
+            <ProposalVoting.Container {...args} activeStage={activeStage} onStageClick={setActiveStage}>
                 <ProposalVoting.Stage
                     name="Token holder voting"
                     status={ProposalVotingStatus.ACTIVE}

--- a/src/modules/components/proposal/proposalVoting/proposalVotingContainer/proposalVotingContainer.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingContainer/proposalVotingContainer.tsx
@@ -12,13 +12,17 @@ export interface IProposalVotingContainerProps extends ComponentProps<'div'> {
      */
     description: string;
     /**
-     * Active stage that will be expanded by default for multi-stage proposals.
+     * Active stage that will be expanded for multi-stage proposals.
      */
     activeStage?: string;
+    /**
+     * Callback called when the user selects a stage, to be used for expanding the current active stage for multi-stage proposals.
+     */
+    onStageClick?: (stage?: string) => void;
 }
 
 export const ProposalVotingContainer: React.FC<IProposalVotingContainerProps> = (props) => {
-    const { title, description, className, children, activeStage, ...otherProps } = props;
+    const { title, description, className, children, activeStage, onStageClick, ...otherProps } = props;
 
     const processedChildren = Children.toArray(children);
     const isMultiStage = processedChildren.length > 1;
@@ -30,7 +34,7 @@ export const ProposalVotingContainer: React.FC<IProposalVotingContainerProps> = 
                 <p className="text-base font-normal leading-normal text-neutral-500">{description}</p>
             </div>
             {isMultiStage && (
-                <Accordion.Container isMulti={false} defaultValue={activeStage}>
+                <Accordion.Container isMulti={false} value={activeStage} onValueChange={onStageClick}>
                     {processedChildren.map((child, index) =>
                         React.isValidElement(child)
                             ? React.cloneElement(child, { ...child.props, index, isMultiStage })

--- a/src/modules/components/proposal/proposalVoting/proposalVotingStage/proposalVotingStage.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingStage/proposalVotingStage.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import { AccordionContainer } from '../../../../../core';
 import { testLogger } from '../../../../../core/test';
 import { ProposalVotingStatus } from '../../proposalUtils';
-import { ProposalVotingTab } from '../proposalVotingDefinitions';
 import { type IProposalVotingStageProps, ProposalVotingStage } from './proposalVotingStage';
 
 jest.mock('../proposalVotingStageStatus', () => ({
@@ -75,10 +74,11 @@ describe('<ProposalVotingStage /> component', () => {
         expect(screen.getByRole('tab', { name: 'Breakdown' })).toHaveAttribute('aria-selected', 'true');
     });
 
-    it('the defaultTabs property overrides the internal processed tab', () => {
-        const defaultTab = ProposalVotingTab.BREAKDOWN;
+    it('correctly updates the active-tab when the stage status changes', () => {
         const status = ProposalVotingStatus.PENDING;
-        render(createTestComponent({ defaultTab, status }));
+        const { rerender } = render(createTestComponent({ status }));
+        expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'true');
+        rerender(createTestComponent({ status: ProposalVotingStatus.ACTIVE }));
         expect(screen.getByRole('tab', { name: 'Details' })).toHaveAttribute('aria-selected', 'false');
         expect(screen.getByRole('tab', { name: 'Breakdown' })).toHaveAttribute('aria-selected', 'true');
     });


### PR DESCRIPTION
## Description

- The radix-ui accordion does not update the active item when changing the `defaultValue` property. In order to mark the next stage active as soon as the previous stage is advanced, we need to control the accordion value by using the `value` and `onValueChange` accordion properties. Same changes are needed for the `ProposalVotingStage` component to properly update the default voting-tab when a stage status changes from PENDING to ACTIVE

Task: [APP-3626](https://aragonassociation.atlassian.net/browse/APP-3626)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.


[APP-3626]: https://aragonassociation.atlassian.net/browse/APP-3626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ