### PR TITLE
fix: Fix publish library workflow to mark the latest library version as "latest"

### DIFF
--- a/.github/workflows/library-publish.yml
+++ b/.github/workflows/library-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Publish library
         run: |
           yarn config set npmAuthToken ${{ secrets.NPM_TOKEN }}
-          yarn npm publish --tag ${{ steps.package-version.outputs.current-version }} --access public
+          yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Read changelog entry for version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fix command to publish library to correctly mark as `latest` the latest library version
+
 ## [1.0.55] - 2024-11-22
 
 ### Added


### PR DESCRIPTION
## Description

- Fix publish library workflow to mark as `latest` the latest library version

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
-   [x] I have tested my code on the test network.
