### PR TITLE
feat(APP-3645): Adjust ProposalVotingTabs gap for children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   Add gap to `ProposalVotingTabs` so that children will vertically space correctly
+
 ## [1.0.56] - 2024-11-26
 
 ### Added

--- a/src/modules/components/proposal/proposalVoting/proposalVotingTabs/proposalVotingTabs.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingTabs/proposalVotingTabs.tsx
@@ -44,7 +44,7 @@ export const ProposalVotingTabs: React.FC<IProposalVotingTabsProps> = (props) =>
                 />
                 <Tabs.Trigger label={copy.proposalVotingTabs.details} value={ProposalVotingTab.DETAILS} />
             </Tabs.List>
-            <div className="flex grow flex-col" ref={contentRef}>
+            <div className="flex grow flex-col gap-y-2" ref={contentRef}>
                 {children}
             </div>
         </Tabs.Root>

--- a/src/modules/components/proposal/proposalVoting/proposalVotingTabs/proposalVotingTabs.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingTabs/proposalVotingTabs.tsx
@@ -44,7 +44,7 @@ export const ProposalVotingTabs: React.FC<IProposalVotingTabsProps> = (props) =>
                 />
                 <Tabs.Trigger label={copy.proposalVotingTabs.details} value={ProposalVotingTab.DETAILS} />
             </Tabs.List>
-            <div className="flex grow flex-col gap-y-2" ref={contentRef}>
+            <div className="flex grow flex-col gap-y-2 md:gap-y-3" ref={contentRef}>
                 {children}
             </div>
         </Tabs.Root>


### PR DESCRIPTION
## Description

Quick adjust for ProposalVotingTabs gap so prop voting plugin footer sits correctly below

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran all tests with success and extended them if necessary.
-   [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before
        the latest version.
