### PR TITLE
feat(APP-3309): Support type property on the buttons of the DialogFooter core component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Update minor and patch NPM dependencies
+- Support `type` property on the buttons of the `<Dialog.Footer />` core component
 
 ## [1.0.57] - 2024-11-29
 

--- a/src/core/components/dialogs/dialog/dialogFooter/dialogFooter.tsx
+++ b/src/core/components/dialogs/dialog/dialogFooter/dialogFooter.tsx
@@ -4,7 +4,7 @@ import { Button, type IButtonBaseProps } from '../../../button';
 
 export type IDialogFooterAction = (
     | Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>
-    | Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>
+    | Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'type'>
 ) &
     Pick<IButtonBaseProps, 'iconRight' | 'iconLeft' | 'disabled' | 'isLoading'> & {
         /**


### PR DESCRIPTION
## Description

- Support `type` property on the buttons of the `<Dialog.Footer />` core component

Task: [APP-3309](https://aragonassociation.atlassian.net/browse/APP-3309)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before the
      latest version.
- [x] I have tested my code on the test network.


[APP-3309]: https://aragonassociation.atlassian.net/browse/APP-3309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ