### PR TITLE
fix(APP-3556): Add correct block explorer links to actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Updated `hash` property to be optional on the `AssetTransfer` module component
-- Added link to the block explorer for members on the `ProposalActionChangeMembers` module component
-- Added receiver block explorer link to the `ProposalActionTokenMint` module component
+- Update `hash` property to be optional on the `AssetTransfer` module component
+- Add link to the block explorer for members on the `ProposalActionChangeMembers` module component
+- Add receiver block explorer link to the `ProposalActionTokenMint` module component
 
 ## [1.0.60] - 2024-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Remove `hash` property al on the `AssetTransfer` module component and add `assetAddress` property for generating link to asset on the block explorer
+- Remove `hash` property al on the `AssetTransfer` module component and add `assetAddress` property for generating link
+  to asset on the block explorer
 - Add link to the block explorer for members on the `ProposalActionChangeMembers` module component
 - Add receiver block explorer link to the `ProposalActionTokenMint` module component
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Remove `hash` property al on the `AssetTransfer` module component and add `assetAddress` property
+- Remove `hash` property on the `AssetTransfer` module component and add optional `assetAddress` property
 - Add link to the block explorer for members on the `ProposalActionChangeMembers` module component
 - Add receiver block explorer link to the `ProposalActionTokenMint` module component
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `hash` property to be optional on the `AssetTransfer` module component
+- Added link to the block explorer for members on the `ProposalActionChangeMembers` module component
+- Added receiver block explorer link to the `ProposalActionTokenMint` module component
+
 ## [1.0.60] - 2024-12-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Update `hash` property to be optional on the `AssetTransfer` module component
+- Remove `hash` property al on the `AssetTransfer` module component and add `assetAddress` property for generating link to asset on the block explorer
 - Add link to the block explorer for members on the `ProposalActionChangeMembers` module component
 - Add receiver block explorer link to the `ProposalActionTokenMint` module component
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Remove `hash` property al on the `AssetTransfer` module component and add `assetAddress` property for generating link
-  to asset on the block explorer
+- Remove `hash` property al on the `AssetTransfer` module component and add `assetAddress` property
 - Add link to the block explorer for members on the `ProposalActionChangeMembers` module component
 - Add receiver block explorer link to the `ProposalActionTokenMint` module component
 

--- a/src/modules/components/asset/assetTransfer/assetTransfer.stories.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.stories.tsx
@@ -28,7 +28,6 @@ export const Default: Story = {
         assetSymbol: 'ETH',
         assetAmount: 1,
         assetName: 'Ethereum',
-        assetAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         assetFiatPrice: 3850,
         chainId: 1,
     },
@@ -41,8 +40,8 @@ export const Fallback: Story = {
     args: {
         sender: { address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' },
         recipient: { address: '0x168dAa4529bf88369ac8c1ABA5A2ad8CF2A61Fb9' },
-        assetName: 'Ethereum',
-        assetSymbol: 'ETH',
+        assetName: 'USDC',
+        assetSymbol: 'USDC',
         assetAmount: 1,
         assetAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     },

--- a/src/modules/components/asset/assetTransfer/assetTransfer.stories.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
         assetSymbol: 'ETH',
         assetAmount: 1,
         assetName: 'Ethereum',
-        assetAddress: '0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce',
+        assetAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         assetFiatPrice: 3850,
         chainId: 1,
     },
@@ -44,7 +44,7 @@ export const Fallback: Story = {
         assetName: 'Ethereum',
         assetSymbol: 'ETH',
         assetAmount: 1,
-        assetAddress: '0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce',
+        assetAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     },
 };
 

--- a/src/modules/components/asset/assetTransfer/assetTransfer.stories.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
         assetSymbol: 'ETH',
         assetAmount: 1,
         assetName: 'Ethereum',
-        hash: '0xf006e9454ad77c5e8e6f54106c6939d3d8b68ae16fc216d67c752f54adb21fc6',
+        assetAddress: '0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce',
         assetFiatPrice: 3850,
         chainId: 1,
     },
@@ -44,7 +44,7 @@ export const Fallback: Story = {
         assetName: 'Ethereum',
         assetSymbol: 'ETH',
         assetAmount: 1,
-        hash: '0xf006e9454ad77c5e8e6f54106c6939d3d8b68ae16fc216d67c752f54adb21fc6',
+        assetAddress: '0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce',
     },
 };
 

--- a/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
@@ -57,10 +57,10 @@ describe('<AssetTransfer /> component', () => {
 
     it('configures and applies the correct link for asset when asset address is defined', () => {
         const assetAddress = '0x0ca620e2dd3147658b8a042b3e7b7cd6f5fa043bf3625140c0dbddcabf47dfb9';
-        render(createTestComponent({ assetAddress, recipient: { address: '0x1' } }));
+        render(createTestComponent({ assetAddress }));
 
         const links = screen.getByRole('link');
-        const expectedTransactionLink = `https://etherscan.io/token/${assetAddress}?a=0x1`;
+        const expectedTransactionLink = `https://etherscan.io/token/${assetAddress}`;
 
         expect(links).toHaveAttribute('href', expectedTransactionLink);
     });

--- a/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
@@ -56,13 +56,22 @@ describe('<AssetTransfer /> component', () => {
         expect(screen.getAllByTestId('asset-transfer-address')).toHaveLength(2);
     });
 
-    it('configures and applies the correct link for asset', () => {
+    it('configures and applies the correct link for asset when asset address is defined', () => {
         const assetAddress = '0x0ca620e2dd3147658b8a042b3e7b7cd6f5fa043bf3625140c0dbddcabf47dfb9';
-        render(createTestComponent({ assetAddress }));
+        render(createTestComponent({ assetAddress, recipient: { address: '0x1' } }));
 
         const links = screen.getByRole('link');
-        const expectedTransactionLink = `https://etherscan.io/token/${assetAddress}`;
+        const expectedTransactionLink = `https://etherscan.io/token/${assetAddress}?a=0x1`;
 
         expect(links).toHaveAttribute('href', expectedTransactionLink);
     });
+
+    it('does not render block explorer link for asset when asset address is not defined', () => {
+        const assetAddress = undefined;
+        render(createTestComponent({ assetAddress }));
+
+        const links = screen.queryByRole('link');
+        expect(links).not.toBeInTheDocument();
+    });
+
 });

--- a/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
@@ -14,7 +14,7 @@ describe('<AssetTransfer /> component', () => {
             assetSymbol: 'ETH',
             assetAmount: 1,
             assetName: 'Ethereum',
-            hash: '0xf006e9454ad77c5e8e6f54106c6939d3d8b68ae16fc216d67c752f54adb21fc6',
+            assetAddress: '0x1',
             ...props,
         };
 
@@ -56,12 +56,12 @@ describe('<AssetTransfer /> component', () => {
         expect(screen.getAllByTestId('asset-transfer-address')).toHaveLength(2);
     });
 
-    it('configures and applies the correct link for transfer tx', () => {
-        const hash = '0x0ca620e2dd3147658b8a042b3e7b7cd6f5fa043bf3625140c0dbddcabf47dfb9';
-        render(createTestComponent({ hash }));
+    it('configures and applies the correct link for asset', () => {
+        const assetAddress = '0x0ca620e2dd3147658b8a042b3e7b7cd6f5fa043bf3625140c0dbddcabf47dfb9';
+        render(createTestComponent({ assetAddress }));
 
         const links = screen.getByRole('link');
-        const expectedTransactionLink = `https://etherscan.io/tx/${hash}`;
+        const expectedTransactionLink = `https://etherscan.io/token/${assetAddress}`;
 
         expect(links).toHaveAttribute('href', expectedTransactionLink);
     });

--- a/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
@@ -14,7 +14,6 @@ describe('<AssetTransfer /> component', () => {
             assetSymbol: 'ETH',
             assetAmount: 1,
             assetName: 'Ethereum',
-            assetAddress: '0x1',
             ...props,
         };
 

--- a/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.test.tsx
@@ -73,5 +73,4 @@ describe('<AssetTransfer /> component', () => {
         const links = screen.queryByRole('link');
         expect(links).not.toBeInTheDocument();
     });
-
 });

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Avatar, AvatarIcon, DataListItem, IconType, NumberFormat, formatterUtils } from '../../../../core';
+import { Avatar, AvatarIcon, DataList, IconType, NumberFormat, formatterUtils } from '../../../../core';
 import { ChainEntityType, useBlockExplorer } from '../../../hooks';
 import { type ICompositeAddress, type IWeb3ComponentProps } from '../../../types';
 import { AssetTransferAddress } from './assetTransferAddress';
@@ -95,7 +95,12 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                 />
                 <AssetTransferAddress txRole="recipient" participant={recipient} addressUrl={recipientUrl} />
             </div>
-            <DataListItem href={assetUrl} target="_blank" rel="noopener noreferrer" className={assetTransferClassNames}>
+            <DataList.Item
+                href={assetUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={assetTransferClassNames}
+            >
                 <div className="flex items-center space-x-3 md:space-x-4">
                     <Avatar responsiveSize={{ md: 'md' }} src={assetIconSrc} />
                     <span className="text-sm leading-tight text-neutral-800 md:text-base">{assetName}</span>
@@ -104,7 +109,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                     <span className="text-sm leading-tight text-neutral-800 md:text-base">{formattedTokenAmount}</span>
                     <span className="text-sm leading-tight text-neutral-500 md:text-base">{formattedFiatValue}</span>
                 </div>
-            </DataListItem>
+            </DataList.Item>
         </div>
     );
 };

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -20,7 +20,7 @@ export interface IAssetTransferProps extends IWeb3ComponentProps {
     /**
      * Address of the asset transferred.
      */
-    assetAddress: string;
+    assetAddress?: string;
     /**
      * Icon URL of the transferred asset.
      */
@@ -57,7 +57,10 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
 
     const senderUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: sender.address });
     const recipientUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: recipient.address });
-    const assetUrl = buildEntityUrl({ type: ChainEntityType.TOKEN, id: assetAddress });
+    const assetUrl = buildEntityUrl({
+        type: ChainEntityType.TOKEN,
+        id: assetAddress ? `${assetAddress}?a=${recipient.address}` : undefined,
+    });
 
     const formattedTokenValue = formatterUtils.formatNumber(assetAmount, {
         format: NumberFormat.TOKEN_AMOUNT_SHORT,

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -74,9 +74,8 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
 
     const baseClassnames =
         'flex h-16 w-full items-center justify-between rounded-xl border border-neutral-100 bg-neutral-0 px-4 md:h-20 md:px-6';
-    const linkClassnames = hash
-        ? 'hover:border-neutral-200 hover:shadow-neutral-md focus:outline-none focus-visible:rounded-xl focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset'
-        : '';
+    const linkClassnames =
+        'hover:border-neutral-200 hover:shadow-neutral-md focus:outline-none focus-visible:rounded-xl focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset';
 
     const AssetTransferContent = (
         <>

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -57,10 +57,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
 
     const senderUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: sender.address });
     const recipientUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: recipient.address });
-    const assetUrl = buildEntityUrl({
-        type: ChainEntityType.TOKEN,
-        id: assetAddress ? `${assetAddress}?a=${recipient.address}` : undefined,
-    });
+    const assetUrl = buildEntityUrl({ type: ChainEntityType.TOKEN, id: assetAddress });
 
     const formattedTokenValue = formatterUtils.formatNumber(assetAmount, {
         format: NumberFormat.TOKEN_AMOUNT_SHORT,

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -78,8 +78,6 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
         ? 'hover:border-neutral-200 hover:shadow-neutral-md focus:outline-none focus-visible:rounded-xl focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset'
         : '';
 
-    const assetTransferClassNames = classNames(baseClassnames, linkClassnames);
-
     const AssetTransferContent = (
         <>
             <div className="flex items-center space-x-3 md:space-x-4">
@@ -112,12 +110,12 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                     href={transactionUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className={assetTransferClassNames}
+                    className={classNames(baseClassnames, linkClassnames)}
                 >
                     {AssetTransferContent}
                 </LinkBase>
             ) : (
-                <div className={assetTransferClassNames}>{AssetTransferContent}</div>
+                <div className={baseClassnames}>{AssetTransferContent}</div>
             )}
         </div>
     );

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Avatar, AvatarIcon, IconType, LinkBase, NumberFormat, formatterUtils } from '../../../../core';
+import { Avatar, AvatarIcon, DataListItem, IconType, NumberFormat, formatterUtils } from '../../../../core';
 import { ChainEntityType, useBlockExplorer } from '../../../hooks';
 import { type ICompositeAddress, type IWeb3ComponentProps } from '../../../types';
 import { AssetTransferAddress } from './assetTransferAddress';
@@ -18,6 +18,10 @@ export interface IAssetTransferProps extends IWeb3ComponentProps {
      */
     assetName: string;
     /**
+     * Address of the asset transferred.
+     */
+    assetAddress: string;
+    /**
      * Icon URL of the transferred asset.
      */
     assetIconSrc?: string;
@@ -33,10 +37,6 @@ export interface IAssetTransferProps extends IWeb3ComponentProps {
      * Price per asset in fiat.
      */
     assetFiatPrice?: number | string;
-    /**
-     * Transaction hash.
-     */
-    hash?: string;
 }
 
 export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
@@ -44,12 +44,12 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
         sender,
         recipient,
         assetName,
+        assetAddress,
         assetIconSrc,
         assetAmount,
         assetSymbol,
         assetFiatPrice,
         chainId,
-        hash,
         wagmiConfig,
     } = props;
 
@@ -57,7 +57,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
 
     const senderUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: sender.address });
     const recipientUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: recipient.address });
-    const transactionUrl = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: hash });
+    const assetUrl = buildEntityUrl({ type: ChainEntityType.TOKEN, id: assetAddress });
 
     const formattedTokenValue = formatterUtils.formatNumber(assetAmount, {
         format: NumberFormat.TOKEN_AMOUNT_SHORT,
@@ -72,23 +72,14 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
         fallback: ` `,
     });
 
-    const baseClassnames =
-        'flex h-16 w-full items-center justify-between rounded-xl border border-neutral-100 bg-neutral-0 px-4 md:h-20 md:px-6';
-    const linkClassnames =
-        'hover:border-neutral-200 hover:shadow-neutral-md focus:outline-none focus-visible:rounded-xl focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset';
-
-    const AssetTransferContent = (
-        <>
-            <div className="flex items-center space-x-3 md:space-x-4">
-                <Avatar responsiveSize={{ md: 'md' }} src={assetIconSrc} />
-                <span className="text-sm leading-tight text-neutral-800 md:text-base">{assetName}</span>
-            </div>
-            <div className="flex flex-col items-end justify-end">
-                <span className="text-sm leading-tight text-neutral-800 md:text-base">{formattedTokenAmount}</span>
-                <span className="text-sm leading-tight text-neutral-500 md:text-base">{formattedFiatValue}</span>
-            </div>
-        </>
+    const assetTransferClassNames = classNames(
+        'flex h-16 w-full items-center justify-between rounded-xl border border-neutral-100 bg-neutral-0 px-4', // base
+        'hover:border-neutral-200 hover:shadow-neutral-md', // hover
+        'focus:outline-none focus-visible:rounded-xl focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset', // focus
+        'active:border-neutral-300 active:shadow-none', // active
+        'md:h-20 md:px-6', // responsive
     );
+
     return (
         <div className="flex size-full flex-col gap-y-2 md:gap-y-3">
             <div className="relative flex h-full flex-col rounded-xl bg-neutral-0 md:flex-row">
@@ -104,18 +95,16 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                 />
                 <AssetTransferAddress txRole="recipient" participant={recipient} addressUrl={recipientUrl} />
             </div>
-            {hash ? (
-                <LinkBase
-                    href={transactionUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={classNames(baseClassnames, linkClassnames)}
-                >
-                    {AssetTransferContent}
-                </LinkBase>
-            ) : (
-                <div className={baseClassnames}>{AssetTransferContent}</div>
-            )}
+            <DataListItem href={assetUrl} target="_blank" rel="noopener noreferrer" className={assetTransferClassNames}>
+                <div className="flex items-center space-x-3 md:space-x-4">
+                    <Avatar responsiveSize={{ md: 'md' }} src={assetIconSrc} />
+                    <span className="text-sm leading-tight text-neutral-800 md:text-base">{assetName}</span>
+                </div>
+                <div className="flex flex-col items-end justify-end">
+                    <span className="text-sm leading-tight text-neutral-800 md:text-base">{formattedTokenAmount}</span>
+                    <span className="text-sm leading-tight text-neutral-500 md:text-base">{formattedFiatValue}</span>
+                </div>
+            </DataListItem>
         </div>
     );
 };

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Avatar, AvatarIcon, IconType, LinkBase, NumberFormat, formatterUtils } from '../../../../core';
+import { Avatar, AvatarIcon, IconType, NumberFormat, formatterUtils } from '../../../../core';
 import { ChainEntityType, useBlockExplorer } from '../../../hooks';
 import { type ICompositeAddress, type IWeb3ComponentProps } from '../../../types';
 import { AssetTransferAddress } from './assetTransferAddress';
@@ -33,10 +33,6 @@ export interface IAssetTransferProps extends IWeb3ComponentProps {
      * Price per asset in fiat.
      */
     assetFiatPrice?: number | string;
-    /**
-     * Transaction hash.
-     */
-    hash: string;
 }
 
 export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
@@ -49,7 +45,6 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
         assetSymbol,
         assetFiatPrice,
         chainId,
-        hash,
         wagmiConfig,
     } = props;
 
@@ -57,7 +52,6 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
 
     const senderUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: sender.address });
     const recipientUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: recipient.address });
-    const transactionUrl = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: hash });
 
     const formattedTokenValue = formatterUtils.formatNumber(assetAmount, {
         format: NumberFormat.TOKEN_AMOUNT_SHORT,
@@ -74,9 +68,6 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
 
     const assetTransferClassNames = classNames(
         'flex h-16 w-full items-center justify-between rounded-xl border border-neutral-100 bg-neutral-0 px-4', // base
-        'hover:border-neutral-200 hover:shadow-neutral-md', // hover
-        'focus:outline-none focus-visible:rounded-xl focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset', // focus
-        'active:border-neutral-300 active:shadow-none', // active
         'md:h-20 md:px-6', // responsive
     );
 
@@ -95,12 +86,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                 />
                 <AssetTransferAddress txRole="recipient" participant={recipient} addressUrl={recipientUrl} />
             </div>
-            <LinkBase
-                href={transactionUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={assetTransferClassNames}
-            >
+            <div className={assetTransferClassNames}>
                 <div className="flex items-center space-x-3 md:space-x-4">
                     <Avatar responsiveSize={{ md: 'md' }} src={assetIconSrc} />
                     <span className="text-sm leading-tight text-neutral-800 md:text-base">{assetName}</span>
@@ -109,7 +95,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                     <span className="text-sm leading-tight text-neutral-800 md:text-base">{formattedTokenAmount}</span>
                     <span className="text-sm leading-tight text-neutral-500 md:text-base">{formattedFiatValue}</span>
                 </div>
-            </LinkBase>
+            </div>
         </div>
     );
 };

--- a/src/modules/components/asset/assetTransfer/assetTransfer.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransfer.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { Avatar, AvatarIcon, IconType, NumberFormat, formatterUtils } from '../../../../core';
+import { Avatar, AvatarIcon, IconType, LinkBase, NumberFormat, formatterUtils } from '../../../../core';
 import { ChainEntityType, useBlockExplorer } from '../../../hooks';
 import { type ICompositeAddress, type IWeb3ComponentProps } from '../../../types';
 import { AssetTransferAddress } from './assetTransferAddress';
@@ -33,6 +33,10 @@ export interface IAssetTransferProps extends IWeb3ComponentProps {
      * Price per asset in fiat.
      */
     assetFiatPrice?: number | string;
+    /**
+     * Transaction hash.
+     */
+    hash?: string;
 }
 
 export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
@@ -45,6 +49,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
         assetSymbol,
         assetFiatPrice,
         chainId,
+        hash,
         wagmiConfig,
     } = props;
 
@@ -52,6 +57,7 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
 
     const senderUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: sender.address });
     const recipientUrl = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: recipient.address });
+    const transactionUrl = buildEntityUrl({ type: ChainEntityType.TRANSACTION, id: hash });
 
     const formattedTokenValue = formatterUtils.formatNumber(assetAmount, {
         format: NumberFormat.TOKEN_AMOUNT_SHORT,
@@ -66,11 +72,26 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
         fallback: ` `,
     });
 
-    const assetTransferClassNames = classNames(
-        'flex h-16 w-full items-center justify-between rounded-xl border border-neutral-100 bg-neutral-0 px-4', // base
-        'md:h-20 md:px-6', // responsive
-    );
+    const baseClassnames =
+        'flex h-16 w-full items-center justify-between rounded-xl border border-neutral-100 bg-neutral-0 px-4 md:h-20 md:px-6';
+    const linkClassnames = hash
+        ? 'hover:border-neutral-200 hover:shadow-neutral-md focus:outline-none focus-visible:rounded-xl focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset'
+        : '';
 
+    const assetTransferClassNames = classNames(baseClassnames, linkClassnames);
+
+    const AssetTransferContent = (
+        <>
+            <div className="flex items-center space-x-3 md:space-x-4">
+                <Avatar responsiveSize={{ md: 'md' }} src={assetIconSrc} />
+                <span className="text-sm leading-tight text-neutral-800 md:text-base">{assetName}</span>
+            </div>
+            <div className="flex flex-col items-end justify-end">
+                <span className="text-sm leading-tight text-neutral-800 md:text-base">{formattedTokenAmount}</span>
+                <span className="text-sm leading-tight text-neutral-500 md:text-base">{formattedFiatValue}</span>
+            </div>
+        </>
+    );
     return (
         <div className="flex size-full flex-col gap-y-2 md:gap-y-3">
             <div className="relative flex h-full flex-col rounded-xl bg-neutral-0 md:flex-row">
@@ -86,16 +107,18 @@ export const AssetTransfer: React.FC<IAssetTransferProps> = (props) => {
                 />
                 <AssetTransferAddress txRole="recipient" participant={recipient} addressUrl={recipientUrl} />
             </div>
-            <div className={assetTransferClassNames}>
-                <div className="flex items-center space-x-3 md:space-x-4">
-                    <Avatar responsiveSize={{ md: 'md' }} src={assetIconSrc} />
-                    <span className="text-sm leading-tight text-neutral-800 md:text-base">{assetName}</span>
-                </div>
-                <div className="flex flex-col items-end justify-end">
-                    <span className="text-sm leading-tight text-neutral-800 md:text-base">{formattedTokenAmount}</span>
-                    <span className="text-sm leading-tight text-neutral-500 md:text-base">{formattedFiatValue}</span>
-                </div>
-            </div>
+            {hash ? (
+                <LinkBase
+                    href={transactionUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={assetTransferClassNames}
+                >
+                    {AssetTransferContent}
+                </LinkBase>
+            ) : (
+                <div className={assetTransferClassNames}>{AssetTransferContent}</div>
+            )}
         </div>
     );
 };

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { modulesCopy } from '../../../../../assets';
+import { GukModulesProvider } from '../../../../gukModulesProvider';
 import { ProposalActionType } from '../../proposalActionsDefinitions';
 import { ProposalActionChangeMembers } from './proposalActionChangeMembers';
 import type { IProposalActionChangeMembersProps } from './proposalActionChangeMembers.api';
@@ -15,7 +16,11 @@ describe('<ProposalActionChangeMembers /> component', () => {
             ...props,
         };
 
-        return <ProposalActionChangeMembers {...completeProps} />;
+        return (
+            <GukModulesProvider>
+                <ProposalActionChangeMembers {...completeProps} />
+            </GukModulesProvider>
+        );
     };
 
     it('renders the existing members correctly', () => {

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
@@ -6,6 +6,11 @@ import { ProposalActionChangeMembers } from './proposalActionChangeMembers';
 import type { IProposalActionChangeMembersProps } from './proposalActionChangeMembers.api';
 import { generateProposalActionChangeMembers } from './proposalActionChangeMembers.testUtils';
 
+jest.mock('../../../../member/memberDataListItem/memberDataListItemStructure', () => ({
+    MemberDataListItemStructure: ({ href }: { href: string }) => (
+        <div data-testid="member-data-list-item" data-href={href} />
+    ),
+}));
 describe('<ProposalActionChangeMembers /> component', () => {
     const createTestComponent = (props?: Partial<IProposalActionChangeMembersProps>) => {
         const completeProps: IProposalActionChangeMembersProps = {
@@ -67,7 +72,7 @@ describe('<ProposalActionChangeMembers /> component', () => {
         const action = generateProposalActionChangeMembers({ members });
         render(createTestComponent({ action }));
 
-        const blockExplorerLink = screen.getByRole('link');
-        expect(blockExplorerLink).toHaveAttribute('href', `https://etherscan.io/address/${members[0].address}`);
+        const memberItem = screen.getByTestId('member-data-list-item');
+        expect(memberItem).toHaveAttribute('data-href', `https://etherscan.io/address/${members[0].address}`);
     });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
@@ -62,11 +62,9 @@ describe('<ProposalActionChangeMembers /> component', () => {
         expect(screen.getByText(modulesCopy.proposalActionChangeMembers.blockNote)).toBeInTheDocument();
     });
 
-    it('renders the correct block explorer link for removed memeber', () => {
-        const type = ProposalActionType.REMOVE_MEMBERS;
-        const currentMembers = 7;
+    it('renders the correct block explorer link for the member', () => {
         const members = [{ address: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e' }];
-        const action = generateProposalActionChangeMembers({ type, currentMembers, members });
+        const action = generateProposalActionChangeMembers({ members });
         render(createTestComponent({ action }));
 
         const blockExplorerLink = screen.getByRole('link');

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.test.tsx
@@ -6,8 +6,6 @@ import { ProposalActionChangeMembers } from './proposalActionChangeMembers';
 import type { IProposalActionChangeMembersProps } from './proposalActionChangeMembers.api';
 import { generateProposalActionChangeMembers } from './proposalActionChangeMembers.testUtils';
 
-jest.mock('../../../../member', () => ({ MemberDataListItem: { Structure: () => <div /> } }));
-
 describe('<ProposalActionChangeMembers /> component', () => {
     const createTestComponent = (props?: Partial<IProposalActionChangeMembersProps>) => {
         const completeProps: IProposalActionChangeMembersProps = {
@@ -62,5 +60,16 @@ describe('<ProposalActionChangeMembers /> component', () => {
     it('renders additional summary information', () => {
         render(createTestComponent());
         expect(screen.getByText(modulesCopy.proposalActionChangeMembers.blockNote)).toBeInTheDocument();
+    });
+
+    it('renders the correct block explorer link for removed memeber', () => {
+        const type = ProposalActionType.REMOVE_MEMBERS;
+        const currentMembers = 7;
+        const members = [{ address: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e' }];
+        const action = generateProposalActionChangeMembers({ type, currentMembers, members });
+        render(createTestComponent({ action }));
+
+        const blockExplorerLink = screen.getByRole('link');
+        expect(blockExplorerLink).toHaveAttribute('href', `https://etherscan.io/address/${members[0].address}`);
     });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeMembers/proposalActionChangeMembers.tsx
@@ -1,12 +1,18 @@
 import { DefinitionList, Heading } from '../../../../../../core';
+import { ChainEntityType, useBlockExplorer } from '../../../../../hooks';
 import { useGukModulesContext } from '../../../../gukModulesProvider';
 import { MemberDataListItem } from '../../../../member';
 import { ProposalActionType } from '../../proposalActionsDefinitions';
 import type { IProposalActionChangeMembersProps } from './proposalActionChangeMembers.api';
 
 export const ProposalActionChangeMembers: React.FC<IProposalActionChangeMembersProps> = (props) => {
-    const { action } = props;
+    const { action, wagmiConfig, chainId } = props;
     const { copy } = useGukModulesContext();
+
+    const { buildEntityUrl } = useBlockExplorer({ chains: wagmiConfig?.chains, chainId });
+
+    const getMemberBlockExplorerLink = (address: string) =>
+        buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address });
 
     return (
         <div className="flex w-full flex-col gap-y-6">
@@ -18,6 +24,8 @@ export const ProposalActionChangeMembers: React.FC<IProposalActionChangeMembersP
                         ensName={member.name}
                         avatarSrc={member.avatarSrc}
                         className="grow basis-60"
+                        href={getMemberBlockExplorerLink(member.address)}
+                        target="_blank"
                     />
                 ))}
             </div>

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.api.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.api.ts
@@ -1,4 +1,4 @@
-import type { ICompositeAddress } from '../../../../../types';
+import type { ICompositeAddress, IWeb3ComponentProps } from '../../../../../types';
 import type {
     IProposalAction,
     IProposalActionComponentProps,
@@ -16,19 +16,20 @@ export interface IProposalActionTokenMintMetadataReceiver extends ICompositeAddr
     newBalance: string;
 }
 
-export interface IProposalActionTokenMint extends IProposalAction {
-    /**
-     * Token mint action.
-     */
-    type: ProposalActionType.TOKEN_MINT;
-    /**
-     * Token receivers.
-     */
-    receiver: IProposalActionTokenMintMetadataReceiver;
-    /**
-     * Token Symbol.
-     */
-    tokenSymbol: string;
-}
+export type IProposalActionTokenMint = IProposalAction &
+    IWeb3ComponentProps & {
+        /**
+         * Token mint action.
+         */
+        type: ProposalActionType.TOKEN_MINT;
+        /**
+         * Token receivers.
+         */
+        receiver: IProposalActionTokenMintMetadataReceiver;
+        /**
+         * Token Symbol.
+         */
+        tokenSymbol: string;
+    };
 
 export interface IProposalActionTokenMintProps extends IProposalActionComponentProps<IProposalActionTokenMint> {}

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.api.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.api.ts
@@ -1,4 +1,4 @@
-import type { ICompositeAddress, IWeb3ComponentProps } from '../../../../../types';
+import type { ICompositeAddress } from '../../../../../types';
 import type {
     IProposalAction,
     IProposalActionComponentProps,
@@ -16,20 +16,19 @@ export interface IProposalActionTokenMintMetadataReceiver extends ICompositeAddr
     newBalance: string;
 }
 
-export type IProposalActionTokenMint = IProposalAction &
-    IWeb3ComponentProps & {
-        /**
-         * Token mint action.
-         */
-        type: ProposalActionType.TOKEN_MINT;
-        /**
-         * Token receivers.
-         */
-        receiver: IProposalActionTokenMintMetadataReceiver;
-        /**
-         * Token Symbol.
-         */
-        tokenSymbol: string;
-    };
+export interface IProposalActionTokenMint extends IProposalAction {
+    /**
+     * Token mint action.
+     */
+    type: ProposalActionType.TOKEN_MINT;
+    /**
+     * Token receivers.
+     */
+    receiver: IProposalActionTokenMintMetadataReceiver;
+    /**
+     * Token Symbol.
+     */
+    tokenSymbol: string;
+}
 
 export interface IProposalActionTokenMintProps extends IProposalActionComponentProps<IProposalActionTokenMint> {}

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.test.tsx
@@ -5,8 +5,23 @@ import type { IProposalActionTokenMintProps } from './proposalActionTokenMint.ap
 import { generateProposalActionTokenMint } from './proposalActionTokenMint.testUtils';
 
 jest.mock('../../../../member/memberDataListItem/memberDataListItemStructure', () => ({
-    MemberDataListItemStructure: ({ tokenAmount, tokenSymbol }: { tokenAmount: number; tokenSymbol: string }) => (
-        <div data-testid="member-data-list-item">{`${tokenAmount.toString()} ${tokenSymbol}`}</div>
+    MemberDataListItemStructure: ({
+        tokenAmount,
+        tokenSymbol,
+        href,
+    }: {
+        tokenAmount: number;
+        tokenSymbol: string;
+        href: string;
+    }) => (
+        <div data-testid="member-data-list-item">
+            <span data-testid="token-display">{`${tokenAmount.toString()} ${tokenSymbol}`}</span>
+            {href && (
+                <a data-testid="block-explorer-link" href={href}>
+                    Member block explorer link
+                </a>
+            )}
+        </div>
     ),
 }));
 
@@ -49,5 +64,20 @@ describe('<ProposalActionTokenMint /> component', () => {
     it('does not render Voting Power label', () => {
         render(createTestComponent());
         expect(screen.queryByText('Voting Power')).not.toBeInTheDocument();
+    });
+
+    it('renders the block explorer link with the correct URL', () => {
+        const receiver = {
+            currentBalance: '0',
+            newBalance: '10',
+            address: '0x123456789',
+            name: 'Some Name',
+        };
+        const action = generateProposalActionTokenMint({ receiver });
+        render(createTestComponent({ action }));
+
+        const blockExplorerLink = screen.getByTestId('block-explorer-link');
+        expect(blockExplorerLink).toHaveAttribute('href', `https://etherscan.io/address/${receiver.address}`);
+        expect(blockExplorerLink).toHaveTextContent('Some Name');
     });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.test.tsx
@@ -78,6 +78,5 @@ describe('<ProposalActionTokenMint /> component', () => {
 
         const blockExplorerLink = screen.getByTestId('block-explorer-link');
         expect(blockExplorerLink).toHaveAttribute('href', `https://etherscan.io/address/${receiver.address}`);
-        expect(blockExplorerLink).toHaveTextContent('Some Name');
     });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.test.tsx
@@ -13,16 +13,7 @@ jest.mock('../../../../member/memberDataListItem/memberDataListItemStructure', (
         tokenAmount: number;
         tokenSymbol: string;
         href: string;
-    }) => (
-        <div data-testid="member-data-list-item">
-            <span data-testid="token-display">{`${tokenAmount.toString()} ${tokenSymbol}`}</span>
-            {href && (
-                <a data-testid="block-explorer-link" href={href}>
-                    Member block explorer link
-                </a>
-            )}
-        </div>
-    ),
+    }) => <div data-testid="member-data-list-item" data-href={href}>{`${tokenAmount.toString()} ${tokenSymbol}`}</div>,
 }));
 
 describe('<ProposalActionTokenMint /> component', () => {
@@ -75,8 +66,7 @@ describe('<ProposalActionTokenMint /> component', () => {
         };
         const action = generateProposalActionTokenMint({ receiver });
         render(createTestComponent({ action }));
-
-        const blockExplorerLink = screen.getByTestId('block-explorer-link');
-        expect(blockExplorerLink).toHaveAttribute('href', `https://etherscan.io/address/${receiver.address}`);
+        const memberItem = screen.getByTestId('member-data-list-item');
+        expect(memberItem).toHaveAttribute('data-href', `https://etherscan.io/address/${receiver.address}`);
     });
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionTokenMint/proposalActionTokenMint.tsx
@@ -1,10 +1,14 @@
+import { ChainEntityType, useBlockExplorer } from '../../../../../hooks';
 import { MemberDataListItemStructure } from '../../../../member';
 import type { IProposalActionTokenMintProps } from './proposalActionTokenMint.api';
 
 export const ProposalActionTokenMint: React.FC<IProposalActionTokenMintProps> = (props) => {
-    const { action } = props;
+    const { action, wagmiConfig, chainId } = props;
     const { tokenSymbol, receiver } = action;
     const { currentBalance, newBalance, address, name, avatarSrc } = receiver;
+
+    const { buildEntityUrl } = useBlockExplorer({ chains: wagmiConfig?.chains, chainId });
+    const receiverBlockExplorerLink = buildEntityUrl({ type: ChainEntityType.ADDRESS, id: address });
 
     const mintedTokenAmount = +newBalance - +currentBalance;
 
@@ -18,6 +22,8 @@ export const ProposalActionTokenMint: React.FC<IProposalActionTokenMintProps> = 
                 tokenAmount={mintedTokenAmount}
                 tokenSymbol={tokenSymbol}
                 hideLabelTokenVoting={true}
+                href={receiverBlockExplorerLink}
+                target="_blank"
             />
         </div>
     );

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.api.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.api.tsx
@@ -17,7 +17,7 @@ export interface IProposalActionWithdrawTokenAsset {
     /**
      * Address of the token.
      */
-    address: string;
+    address?: string;
     /**
      * URL of the token logo.
      */

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.api.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.api.tsx
@@ -15,6 +15,10 @@ export interface IProposalActionWithdrawTokenAsset {
      */
     symbol: string;
     /**
+     * Address of the token.
+     */
+    address: string;
+    /**
      * URL of the token logo.
      */
     logo: string;

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.stories.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.stories.tsx
@@ -29,6 +29,7 @@ export const Default: Story = {
                 logo: 'https://s2.coinmarketcap.com/static/img/coins/64x64/5994.png',
                 priceUsd: '0.00002459',
                 decimals: 18,
+                address: '0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce',
             },
             amount: '9784653197',
         }),

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.test.tsx
@@ -25,7 +25,14 @@ describe('<ProposalActionWithdrawToken /> component', () => {
     it('passes correct props to AssetTransfer', () => {
         const sender = { address: '0x1D03D98c0aac1f83860cec5156116FE68725642E' };
         const receiver = { address: '0x1D03D98c0aac1f83860cec5156116FE687259999' };
-        const token = { name: 'Bitcoin', symbol: 'BTC', logo: 'btc-logo.png', priceUsd: '50000', decimals: 6 };
+        const token = {
+            name: 'Bitcoin',
+            symbol: 'BTC',
+            logo: 'btc-logo.png',
+            priceUsd: '50000',
+            decimals: 6,
+            address: '0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce',
+        };
         const amount = '10';
         const action = generateProposalActionWithdrawToken({ sender, receiver, token, amount });
 

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.test.tsx
@@ -46,6 +46,7 @@ describe('<ProposalActionWithdrawToken /> component', () => {
                 assetAmount: action.amount,
                 assetSymbol: action.token.symbol,
                 assetIconSrc: action.token.logo,
+                assetAddress: action.token.address,
             }),
             undefined,
         );

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.test.tsx
@@ -39,7 +39,6 @@ describe('<ProposalActionWithdrawToken /> component', () => {
                 assetAmount: action.amount,
                 assetSymbol: action.token.symbol,
                 assetIconSrc: action.token.logo,
-                hash: '',
             }),
             undefined,
         );

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.testUtils.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.testUtils.ts
@@ -9,7 +9,7 @@ export const generateProposalActionWithdrawToken = (
     type: ProposalActionType.WITHDRAW_TOKEN,
     sender: { address: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e' },
     receiver: { address: '0x3f5CE5FBFe3E9af3971dD833D26BA9b5C936F0bE' },
-    token: { name: 'Token name', symbol: 'TTT', logo: '', priceUsd: '1.00', decimals: 18 },
+    token: { name: 'Token name', symbol: 'TTT', logo: '', priceUsd: '1.00', decimals: 18, address: '0x1' },
     amount: '10000000',
     ...action,
 });

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.tsx
@@ -9,6 +9,7 @@ export const ProposalActionWithdrawToken: React.FC<IProposalActionWithdrawTokenP
             sender={action.sender}
             recipient={action.receiver}
             assetName={action.token.name}
+            assetAddress={action.token.address}
             assetAmount={action.amount}
             assetFiatPrice={action.token.priceUsd}
             assetSymbol={action.token.symbol}

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionWithdrawToken/proposalActionWithdrawToken.tsx
@@ -13,8 +13,6 @@ export const ProposalActionWithdrawToken: React.FC<IProposalActionWithdrawTokenP
             assetFiatPrice={action.token.priceUsd}
             assetSymbol={action.token.symbol}
             assetIconSrc={action.token.logo}
-            // TODO: Make hash property on AssetTransfer optional (APP-3430)
-            hash=""
             {...web3Props}
         />
     );


### PR DESCRIPTION
## Description

- Updated `hash` property to be optional on the `AssetTransfer` module component
- Added link to the block explorer for members on the `ProposalActionChangeMembers` module component
- Added receiver block explorer link to the `ProposalActionTokenMint` module component

Task: [APP-3556](https://aragonassociation.atlassian.net/browse/APP-3556)
Task: [APP-3830](https://aragonassociation.atlassian.net/browse/APP-3830)
Task: [APP-3430](https://aragonassociation.atlassian.net/browse/APP-3430)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before the
      latest version.
- [ ] I have tested my code on the test network.


[APP-3556]: https://aragonassociation.atlassian.net/browse/APP-3556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3830]: https://aragonassociation.atlassian.net/browse/APP-3830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-3430]: https://aragonassociation.atlassian.net/browse/APP-3430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ