### PR TITLE
fix(APP-3851): Prevent displacement of placeholder on AddressInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated minimum height of `<AddressInput />` to resolve displacement of placeholder text on mount
+
 ## [1.0.63] - 2025-01-15
 
 ### Changed

--- a/src/core/components/forms/textArea/textArea.tsx
+++ b/src/core/components/forms/textArea/textArea.tsx
@@ -17,7 +17,6 @@ export const TextArea = forwardRef<HTMLTextAreaElement, ITextAreaProps>((props, 
             {...otherContainerProps}
         >
             <textarea
-                rows={1}
                 type="text"
                 className={classNames('min-h-[160px] leading-normal', inputClassName)}
                 ref={ref}

--- a/src/core/components/forms/textArea/textArea.tsx
+++ b/src/core/components/forms/textArea/textArea.tsx
@@ -17,6 +17,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, ITextAreaProps>((props, 
             {...otherContainerProps}
         >
             <textarea
+                rows={1}
                 type="text"
                 className={classNames('min-h-[160px] leading-normal', inputClassName)}
                 ref={ref}

--- a/src/modules/components/address/addressInput/addressInput.tsx
+++ b/src/modules/components/address/addressInput/addressInput.tsx
@@ -213,7 +213,7 @@ export const AddressInput = forwardRef<HTMLTextAreaElement, IAddressInputProps>(
                 onBlur={handleInputBlur}
                 rows={1}
                 className={classNames(
-                    '!md:px-4 resize-none whitespace-normal !px-3',
+                    '!md:px-4 min-h-11 resize-none whitespace-normal !px-3',
                     { 'whitespace-normal': isFocused },
                     inputClassName,
                 )}

--- a/src/modules/components/address/addressInput/addressInput.tsx
+++ b/src/modules/components/address/addressInput/addressInput.tsx
@@ -213,7 +213,8 @@ export const AddressInput = forwardRef<HTMLTextAreaElement, IAddressInputProps>(
                 onBlur={handleInputBlur}
                 rows={1}
                 className={classNames(
-                    '!md:px-4 min-h-11 resize-none whitespace-normal !px-3',
+                    // min-h-11 is required to prevent placeholder displacement
+                    '!md:px-4 min-h-11 resize-none !px-3',
                     { 'whitespace-normal': isFocused },
                     inputClassName,
                 )}


### PR DESCRIPTION
## Description

Adds min-h-11 to address input which keeps interior height of text-area from mounting with style:"height: 0" by default when composed in forms and other components


Task: [APP-3851](https://aragonassociation.atlassian.net/browse/APP-3851)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the [UPCOMING] title and before the
      latest version.


[APP-3851]: https://aragonassociation.atlassian.net/browse/APP-3851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ