### PR TITLE
fix(APP-3882): Use correct native token symbol for asset transfer warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Bump `actions/setup-python` to 5.4.0
-- Update minor and patch dependencies
+- Update minor and patch NPM dependencies
 - Improve code coverage on core and modules components
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix documentation pages on primitive variables
+- Implement native token symbol in asset transfer warning
 
 ## [1.0.65] - 2025-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix documentation pages on primitive variables
-- Implement native token symbol in asset transfer warning for L2 and alt chains
+- Use correct token symbol in asset transfer warning for supported chains
 
 ## [1.0.65] - 2025-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix documentation pages on primitive variables
-- Implement native token symbol in asset transfer warning
+- Implement native token symbol in asset transfer warning for L2 and alt chains
 
 ## [1.0.65] - 2025-01-30
 

--- a/src/modules/assets/copy/modulesCopy.ts
+++ b/src/modules/assets/copy/modulesCopy.ts
@@ -27,8 +27,8 @@ export const modulesCopy = {
     proposalActionsItem: {
         dropdownLabel: 'More',
         nativeSendAlert: 'Proceed with caution',
-        nativeSendDescription: (amount: string) =>
-            `This action attempts to send ${amount} ETH. This could cause the action to fail or result in a loss of funds.`,
+        nativeSendDescription: (amount: string, nativeSymbol: string) =>
+            `This action attempts to send ${amount} ${nativeSymbol}. This could cause the action to fail or result in a loss of funds.`,
         notVerified: {
             function: 'Unknown',
             contract: 'Unverified contract',

--- a/src/modules/assets/copy/modulesCopy.ts
+++ b/src/modules/assets/copy/modulesCopy.ts
@@ -27,8 +27,8 @@ export const modulesCopy = {
     proposalActionsItem: {
         dropdownLabel: 'More',
         nativeSendAlert: 'Proceed with caution',
-        nativeSendDescription: (amount: string, nativeSymbol: string) =>
-            `This action attempts to send ${amount} ${nativeSymbol}. This could cause the action to fail or result in a loss of funds.`,
+        nativeSendDescription: (amount: string, symbol: string) =>
+            `This action attempts to send ${amount} ${symbol}. This could cause the action to fail or result in a loss of funds.`,
         notVerified: {
             function: 'Unknown',
             contract: 'Unverified contract',

--- a/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.test.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.test.tsx
@@ -158,11 +158,11 @@ describe('<ProposalActionsItem /> component', () => {
 
     it('renders a warning icon and alert when action value is not zero and action is not a native transfer', async () => {
         const action = generateProposalAction({ value: '1000000000000000000', data: '0xabc' });
-        render(createTestComponent({ action }));
+        render(createTestComponent({ action, chainId: 137 }));
         expect(screen.getByTestId(IconType.WARNING)).toBeInTheDocument();
         await userEvent.click(screen.getByRole('button'));
         expect(screen.getByText(modulesCopy.proposalActionsItem.nativeSendAlert)).toBeInTheDocument();
-        expect(screen.getByText(modulesCopy.proposalActionsItem.nativeSendDescription('1')));
+        expect(screen.getByText(modulesCopy.proposalActionsItem.nativeSendDescription('1', 'POL')));
     });
 
     it('updates active view on view-mode change', async () => {

--- a/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { useRef, useState } from 'react';
 import { formatUnits } from 'viem';
+import { useChains } from 'wagmi';
 import { Accordion, AlertCard, Button, Dropdown, Icon, IconType, invariant, Link, LinkBase } from '../../../../../core';
 import { ChainEntityType, useBlockExplorer } from '../../../../hooks';
 import { addressUtils } from '../../../../utils';
@@ -29,6 +30,10 @@ export const ProposalActionsItem = <TAction extends IProposalAction = IProposalA
 
     const { copy } = useGukModulesContext();
     const { buildEntityUrl } = useBlockExplorer({ chainId });
+
+    const chains = useChains();
+    const chain = chains.find((chain) => chain.id === chainId);
+    const nativeSymbol = chain?.nativeCurrency.symbol ?? 'ETH';
 
     const contentRef = useRef<HTMLDivElement>(null);
     const itemRef = useRef<HTMLDivElement>(null);
@@ -115,7 +120,7 @@ export const ProposalActionsItem = <TAction extends IProposalAction = IProposalA
                         <AlertCard
                             variant="warning"
                             message={copy.proposalActionsItem.nativeSendAlert}
-                            description={copy.proposalActionsItem.nativeSendDescription(formattedValue)}
+                            description={copy.proposalActionsItem.nativeSendDescription(formattedValue, nativeSymbol)}
                         />
                     )}
                     {activeViewMode === 'BASIC' && (

--- a/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsItem/proposalActionsItem.tsx
@@ -33,7 +33,7 @@ export const ProposalActionsItem = <TAction extends IProposalAction = IProposalA
 
     const chains = useChains();
     const chain = chains.find((chain) => chain.id === chainId);
-    const nativeSymbol = chain?.nativeCurrency.symbol ?? 'ETH';
+    const currencySymbol = chain?.nativeCurrency.symbol ?? 'ETH';
 
     const contentRef = useRef<HTMLDivElement>(null);
     const itemRef = useRef<HTMLDivElement>(null);
@@ -120,7 +120,7 @@ export const ProposalActionsItem = <TAction extends IProposalAction = IProposalA
                         <AlertCard
                             variant="warning"
                             message={copy.proposalActionsItem.nativeSendAlert}
-                            description={copy.proposalActionsItem.nativeSendDescription(formattedValue, nativeSymbol)}
+                            description={copy.proposalActionsItem.nativeSendDescription(formattedValue, currencySymbol)}
                         />
                     )}
                     {activeViewMode === 'BASIC' && (


### PR DESCRIPTION
## Description

Uses the config for supported chains to fetch correct token symbol when warning users about native transfers in a proposal action. 

<img width="873" alt="image" src="https://github.com/user-attachments/assets/d728329d-b87a-47b3-bd64-0f38f4213a06" />


Task: [APP-3882](https://aragonassociation.atlassian.net/browse/APP-3882)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the `CHANGELOG.md` file after the [UPCOMING] title and before the latest version
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-3882]: https://aragonassociation.atlassian.net/browse/APP-3882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ