### PR TITLE
feat(APP-3954): Update Tab component to not render the TabList when there is a single child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Update `Tabs.List` component to only render if we have multiple tabs.
+- Update `Tabs.List` component to only render when used with multiple tabs
 - Bump `elliptic` to 6.6.1
 
 ## [1.0.66] - 2025-02-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Update `Tabs.List` component to only render if we have multiple tabs.
+
 ## [1.0.66] - 2025-02-11
 
 ### Changed

--- a/src/core/components/tabs/tabsList/tabsList.test.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.test.tsx
@@ -1,8 +1,7 @@
-// TabsRoot.test.tsx
 import { render, screen } from '@testing-library/react';
 import { Tabs, type ITabsListProps } from '../../tabs';
 
-describe('<Tabs.Root /> component', () => {
+describe('<Tabs.List /> component', () => {
     const createSingleTabTestComponent = (props?: Partial<ITabsListProps>) => {
         const completeProps: ITabsListProps = { ...props };
         return (

--- a/src/core/components/tabs/tabsList/tabsList.test.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.test.tsx
@@ -3,10 +3,18 @@ import { render, screen } from '@testing-library/react';
 import { Tabs, type ITabsListProps } from '../../tabs';
 
 describe('<Tabs.Root /> component', () => {
-    const createTestComponent = (props?: Partial<ITabsListProps>) => {
-        const completeProps: ITabsListProps = {
-            ...props,
-        };
+    const createSingleTabTestComponent = (props?: Partial<ITabsListProps>) => {
+        const completeProps: ITabsListProps = { ...props };
+        return (
+            <Tabs.Root>
+                <Tabs.List {...completeProps}>
+                    <Tabs.Trigger label="Tab 1" value="1" />
+                </Tabs.List>
+            </Tabs.Root>
+        );
+    };
+    const createMultiTabsTestComponent = (props?: Partial<ITabsListProps>) => {
+        const completeProps: ITabsListProps = { ...props };
         return (
             <Tabs.Root>
                 <Tabs.List {...completeProps}>
@@ -18,9 +26,15 @@ describe('<Tabs.Root /> component', () => {
     };
 
     it('should render multiple tab triggers without crashing', () => {
-        render(createTestComponent());
+        render(createMultiTabsTestComponent());
 
         expect(screen.getByText('Tab 1')).toBeInTheDocument();
         expect(screen.getByText('Tab 2')).toBeInTheDocument();
+    });
+
+    it('should render null when only a single tab trigger is present', () => {
+        render(createSingleTabTestComponent());
+
+        expect(screen.queryByText('Tab 1')).not.toBeInTheDocument();
     });
 });

--- a/src/core/components/tabs/tabsList/tabsList.test.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.test.tsx
@@ -1,28 +1,30 @@
 import { render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
-import { Tabs } from '../../tabs';
+import { type ITabsListProps, Tabs } from '../../tabs';
 
 describe('<Tabs.List /> component', () => {
-    const createTestComponent = (children: ReactNode) => (
-        <Tabs.Root>
-            <Tabs.List>{children}</Tabs.List>
-        </Tabs.Root>
-    );
+    const createTestComponent = (props: Partial<ITabsListProps>) => {
+        const completeProps: ITabsListProps = { ...props };
+        return (
+            <Tabs.Root>
+                <Tabs.List {...completeProps} />
+            </Tabs.Root>
+        );
+    };
 
     it('should render multiple tab triggers without crashing', () => {
-        render(
-            createTestComponent([
-                <Tabs.Trigger key="1" label="Tab 1" value="1" />,
-                <Tabs.Trigger key="2" label="Tab 2" value="2" />,
-            ]),
-        );
+        const children = [
+            <Tabs.Trigger key="1" label="Tab 1" value="1" />,
+            <Tabs.Trigger key="2" label="Tab 2" value="2" />,
+        ];
+        render(createTestComponent({ children }));
 
         expect(screen.getByText('Tab 1')).toBeInTheDocument();
         expect(screen.getByText('Tab 2')).toBeInTheDocument();
     });
 
     it('should render null when only a single tab trigger is present', () => {
-        render(createTestComponent(<Tabs.Trigger label="Tab 1" value="1" />));
+        const children = <Tabs.Trigger label="Tab 1" value="1" />;
+        render(createTestComponent({ children }));
 
         expect(screen.queryByText('Tab 1')).not.toBeInTheDocument();
     });

--- a/src/core/components/tabs/tabsList/tabsList.test.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.test.tsx
@@ -3,27 +3,27 @@ import { Tabs } from '../../tabs';
 import type { ReactNode } from 'react';
 
 describe('<Tabs.List /> component', () => {
-    const createTestComponent = (children: ReactNode) => (
-        <Tabs.Root>
-            <Tabs.List>{children}</Tabs.List>
-        </Tabs.Root>
-    );
+  const createTestComponent = (children: ReactNode) => (
+      <Tabs.Root>
+          <Tabs.List>{children}</Tabs.List>
+      </Tabs.Root>
+  );
 
-    it('should render multiple tab triggers without crashing', () => {
-        render(
-            createTestComponent(
-                <>
-                    <Tabs.Trigger label="Tab 1" value="1" />
-                    <Tabs.Trigger label="Tab 2" value="2" />
-                </>,
-            ),
-        );
-        expect(screen.getByText('Tab 1')).toBeInTheDocument();
-        expect(screen.getByText('Tab 2')).toBeInTheDocument();
-    });
+  it('should render multiple tab triggers without crashing', () => {
+      render(
+          createTestComponent([
+              <Tabs.Trigger key="1" label="Tab 1" value="1" />,
+              <Tabs.Trigger key="2" label="Tab 2" value="2" />,
+          ]),
+      );
 
-    it('should render null when only a single tab trigger is present', () => {
-        render(createTestComponent(<Tabs.Trigger label="Tab 1" value="1" />));
-        expect(screen.queryByText('Tab 1')).not.toBeInTheDocument();
-    });
+      expect(screen.getByText('Tab 1')).toBeInTheDocument();
+      expect(screen.getByText('Tab 2')).toBeInTheDocument();
+  });
+
+  it('should render null when only a single tab trigger is present', () => {
+      render(createTestComponent(<Tabs.Trigger label="Tab 1" value="1" />));
+
+      expect(screen.queryByText('Tab 1')).not.toBeInTheDocument();
+  });
 });

--- a/src/core/components/tabs/tabsList/tabsList.test.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.test.tsx
@@ -1,39 +1,29 @@
 import { render, screen } from '@testing-library/react';
-import { Tabs, type ITabsListProps } from '../../tabs';
+import { Tabs } from '../../tabs';
+import type { ReactNode } from 'react';
 
 describe('<Tabs.List /> component', () => {
-    const createSingleTabTestComponent = (props?: Partial<ITabsListProps>) => {
-        const completeProps: ITabsListProps = { ...props };
-        return (
-            <Tabs.Root>
-                <Tabs.List {...completeProps}>
-                    <Tabs.Trigger label="Tab 1" value="1" />
-                </Tabs.List>
-            </Tabs.Root>
-        );
-    };
-    const createMultiTabsTestComponent = (props?: Partial<ITabsListProps>) => {
-        const completeProps: ITabsListProps = { ...props };
-        return (
-            <Tabs.Root>
-                <Tabs.List {...completeProps}>
-                    <Tabs.Trigger label="Tab 1" value="1" />
-                    <Tabs.Trigger label="Tab 2" value="2" />
-                </Tabs.List>
-            </Tabs.Root>
-        );
-    };
+    const createTestComponent = (children: ReactNode) => (
+        <Tabs.Root>
+            <Tabs.List>{children}</Tabs.List>
+        </Tabs.Root>
+    );
 
     it('should render multiple tab triggers without crashing', () => {
-        render(createMultiTabsTestComponent());
-
+        render(
+            createTestComponent(
+                <>
+                    <Tabs.Trigger label="Tab 1" value="1" />
+                    <Tabs.Trigger label="Tab 2" value="2" />
+                </>,
+            ),
+        );
         expect(screen.getByText('Tab 1')).toBeInTheDocument();
         expect(screen.getByText('Tab 2')).toBeInTheDocument();
     });
 
     it('should render null when only a single tab trigger is present', () => {
-        render(createSingleTabTestComponent());
-
+        render(createTestComponent(<Tabs.Trigger label="Tab 1" value="1" />));
         expect(screen.queryByText('Tab 1')).not.toBeInTheDocument();
     });
 });

--- a/src/core/components/tabs/tabsList/tabsList.test.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.test.tsx
@@ -1,29 +1,29 @@
 import { render, screen } from '@testing-library/react';
-import { Tabs } from '../../tabs';
 import type { ReactNode } from 'react';
+import { Tabs } from '../../tabs';
 
 describe('<Tabs.List /> component', () => {
-  const createTestComponent = (children: ReactNode) => (
-      <Tabs.Root>
-          <Tabs.List>{children}</Tabs.List>
-      </Tabs.Root>
-  );
+    const createTestComponent = (children: ReactNode) => (
+        <Tabs.Root>
+            <Tabs.List>{children}</Tabs.List>
+        </Tabs.Root>
+    );
 
-  it('should render multiple tab triggers without crashing', () => {
-      render(
-          createTestComponent([
-              <Tabs.Trigger key="1" label="Tab 1" value="1" />,
-              <Tabs.Trigger key="2" label="Tab 2" value="2" />,
-          ]),
-      );
+    it('should render multiple tab triggers without crashing', () => {
+        render(
+            createTestComponent([
+                <Tabs.Trigger key="1" label="Tab 1" value="1" />,
+                <Tabs.Trigger key="2" label="Tab 2" value="2" />,
+            ]),
+        );
 
-      expect(screen.getByText('Tab 1')).toBeInTheDocument();
-      expect(screen.getByText('Tab 2')).toBeInTheDocument();
-  });
+        expect(screen.getByText('Tab 1')).toBeInTheDocument();
+        expect(screen.getByText('Tab 2')).toBeInTheDocument();
+    });
 
-  it('should render null when only a single tab trigger is present', () => {
-      render(createTestComponent(<Tabs.Trigger label="Tab 1" value="1" />));
+    it('should render null when only a single tab trigger is present', () => {
+        render(createTestComponent(<Tabs.Trigger label="Tab 1" value="1" />));
 
-      expect(screen.queryByText('Tab 1')).not.toBeInTheDocument();
-  });
+        expect(screen.queryByText('Tab 1')).not.toBeInTheDocument();
+    });
 });

--- a/src/core/components/tabs/tabsList/tabsList.test.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.test.tsx
@@ -2,8 +2,11 @@ import { render, screen } from '@testing-library/react';
 import { type ITabsListProps, Tabs } from '../../tabs';
 
 describe('<Tabs.List /> component', () => {
-    const createTestComponent = (props: Partial<ITabsListProps>) => {
-        const completeProps: ITabsListProps = { ...props };
+    const createTestComponent = (props?: Partial<ITabsListProps>) => {
+        const completeProps: ITabsListProps = {
+            ...props,
+        };
+
         return (
             <Tabs.Root>
                 <Tabs.List {...completeProps} />
@@ -11,7 +14,7 @@ describe('<Tabs.List /> component', () => {
         );
     };
 
-    it('should render multiple tab triggers without crashing', () => {
+    it('renders multiple tab triggers', () => {
         const children = [
             <Tabs.Trigger key="1" label="Tab 1" value="1" />,
             <Tabs.Trigger key="2" label="Tab 2" value="2" />,
@@ -22,7 +25,7 @@ describe('<Tabs.List /> component', () => {
         expect(screen.getByText('Tab 2')).toBeInTheDocument();
     });
 
-    it('should render null when only a single tab trigger is present', () => {
+    it('renders null when only a single tab trigger is present', () => {
         const children = <Tabs.Trigger label="Tab 1" value="1" />;
         render(createTestComponent({ children }));
 

--- a/src/core/components/tabs/tabsList/tabsList.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.tsx
@@ -11,9 +11,10 @@ export const TabsList: React.FC<ITabsListProps> = (props) => {
 
     const tabsListClassNames = classNames('flex gap-x-6', { 'border-b border-neutral-100': isUnderlined }, className);
 
-    // Only render the tabs list if there's more than one child
-    // If there is a possibility of only a single tab then we must set either defaultValue or value property
-    // on the Tabs.Root component.
+    /* If there is only a single child then the tabs are redundant and we just show the content
+    In this case we don't render the tabs list. Note that we should always set either a defaultValue or value
+    prop on the Tabs.Root component if there is a possibility of only a single child being present
+    Otherwise no tab will be selected and no content will render */
     if (Children.count(children) === 1) {
         return null;
     }

--- a/src/core/components/tabs/tabsList/tabsList.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.tsx
@@ -1,6 +1,6 @@
 import { TabsList as RadixTabsList } from '@radix-ui/react-tabs';
 import classNames from 'classnames';
-import { useContext, type ComponentProps } from 'react';
+import { Children, useContext, type ComponentProps } from 'react';
 import { TabsContext } from '../tabsRoot/tabsRoot';
 
 export interface ITabsListProps extends ComponentProps<'div'> {}
@@ -10,6 +10,11 @@ export const TabsList: React.FC<ITabsListProps> = (props) => {
     const { isUnderlined } = useContext(TabsContext);
 
     const tabsListClassNames = classNames('flex gap-x-6', { 'border-b border-neutral-100': isUnderlined }, className);
+
+    // Only render the tabs list if there's more than one child
+    if (Children.count(children) === 1) {
+        return null;
+    }
 
     return (
         <RadixTabsList className={tabsListClassNames} {...otherProps}>

--- a/src/core/components/tabs/tabsList/tabsList.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.tsx
@@ -11,10 +11,7 @@ export const TabsList: React.FC<ITabsListProps> = (props) => {
 
     const tabsListClassNames = classNames('flex gap-x-6', { 'border-b border-neutral-100': isUnderlined }, className);
 
-    /* If there is only a single child then the tabs are redundant and we just show the content
-    In this case we don't render the tabs list. Note that we should always set either a defaultValue or value
-    prop on the Tabs.Root component if there is a possibility of only a single child being present
-    Otherwise no tab will be selected and no content will render */
+    // If there is only a single child then the tabs are redundant and we just show the content
     if (Children.count(children) === 1) {
         return null;
     }

--- a/src/core/components/tabs/tabsList/tabsList.tsx
+++ b/src/core/components/tabs/tabsList/tabsList.tsx
@@ -12,6 +12,8 @@ export const TabsList: React.FC<ITabsListProps> = (props) => {
     const tabsListClassNames = classNames('flex gap-x-6', { 'border-b border-neutral-100': isUnderlined }, className);
 
     // Only render the tabs list if there's more than one child
+    // If there is a possibility of only a single tab then we must set either defaultValue or value property
+    // on the Tabs.Root component.
     if (Children.count(children) === 1) {
         return null;
     }

--- a/src/core/components/tabs/tabsRoot/tabsRoot.stories.tsx
+++ b/src/core/components/tabs/tabsRoot/tabsRoot.stories.tsx
@@ -90,5 +90,4 @@ export const SingleTab: Story = {
     ),
 };
 
-
 export default meta;

--- a/src/core/components/tabs/tabsRoot/tabsRoot.stories.tsx
+++ b/src/core/components/tabs/tabsRoot/tabsRoot.stories.tsx
@@ -72,7 +72,7 @@ export const InsideCard: Story = {
 
 /**
  * Usage example of a Tabs component with a single tab with the default value.
- * If there is a chance of only a single tab then we must set either defaultValue or value property
+ * Make sure to set the `defaultValue` or `value` property to select and show the content of the tab.
  */
 export const SingleTab: Story = {
     args: { defaultValue: '1' },

--- a/src/core/components/tabs/tabsRoot/tabsRoot.stories.tsx
+++ b/src/core/components/tabs/tabsRoot/tabsRoot.stories.tsx
@@ -70,4 +70,25 @@ export const InsideCard: Story = {
     render: (args) => <Card className="p-6">{reusableStoryComponent(args)}</Card>,
 };
 
+/**
+ * Usage example of a Tabs component with a single tab with the default value.
+ * If there is a chance of only a single tab then we must set either defaultValue or value property
+ */
+export const SingleTab: Story = {
+    args: { defaultValue: '1' },
+    render: (args) => (
+        <Tabs.Root {...args}>
+            <Tabs.List>
+                <Tabs.Trigger label="Default Tab" value="1" />
+            </Tabs.List>
+            <Tabs.Content value="1">
+                <div className="flex h-24 w-96 items-center justify-center border border-dashed border-info-300 bg-info-100">
+                    Item 1 Content
+                </div>
+            </Tabs.Content>
+        </Tabs.Root>
+    ),
+};
+
+
 export default meta;

--- a/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
+++ b/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
@@ -3,38 +3,55 @@ import { IconType } from '../../icon';
 import { Tabs, type ITabsTriggerProps } from '../../tabs';
 
 describe('<Tabs.Trigger /> component', () => {
-    const createTestComponent = (props?: Partial<ITabsTriggerProps>) => {
-        const completeProps: ITabsTriggerProps = {
-            label: 'Tab 1',
-            value: '1',
-            ...props,
-        };
-
-        return (
-            <Tabs.Root>
-                <Tabs.List>
-                    <Tabs.Trigger {...completeProps} />
-                </Tabs.List>
-            </Tabs.Root>
-        );
-    };
+    const createTestComponent = (tabs: ITabsTriggerProps[]) => (
+        <Tabs.Root defaultValue="1">
+            <Tabs.List>
+                {tabs.map((props, index) => (
+                    <Tabs.Trigger key={index} {...props} />
+                ))}
+            </Tabs.List>
+        </Tabs.Root>
+    );
 
     it('renders a tab', () => {
-        render(createTestComponent());
-        const tab = screen.getByRole('tab');
+        render(
+            createTestComponent([
+                { label: 'Tab 1', value: '1' },
+                { label: 'Tab 2', value: '2' },
+            ]),
+        );
+
+        const tab = screen.getByRole('tab', { name: 'Tab 1' });
         expect(tab).toBeInTheDocument();
         expect(tab.getAttribute('disabled')).toBeNull();
     });
 
     it('renders the icon when iconRight is provided', () => {
         const iconRight = IconType.BLOCKCHAIN_BLOCK;
-        render(createTestComponent({ iconRight }));
+        render(
+            createTestComponent([
+                { label: 'Tab 1', value: '1', iconRight },
+                { label: 'Tab 2', value: '2' },
+            ]),
+        );
+
         expect(screen.getByTestId(iconRight)).toBeInTheDocument();
     });
 
     it('disables the tab when the disabled property is set to true', () => {
-        const disabled = true;
-        render(createTestComponent({ disabled }));
-        expect(screen.getByRole('tab').getAttribute('disabled')).toEqual('');
+        render(
+            createTestComponent([
+                { label: 'Tab 1', value: '1', disabled: true },
+                { label: 'Tab 2', value: '2' },
+            ]),
+        );
+
+        const tab = screen.getByRole('tab', { name: 'Tab 1' });
+        expect(tab.getAttribute('disabled')).toEqual('');
+    });
+
+    it('does not render the Tabs.List or Tabs.Trigger in a single tab setup', () => {
+        render(createTestComponent([{ label: 'Tab 1', value: '1' }]));
+        expect(screen.queryByRole('tab')).not.toBeInTheDocument();
     });
 });

--- a/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
+++ b/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
@@ -22,7 +22,7 @@ describe('<Tabs.Trigger /> component', () => {
 
     it('renders a tab', () => {
         render(createTestComponent());
-        const tab = screen.getByRole('tab', { name: 'Tab 1' });
+        const tab = screen.getByRole('tab');
         expect(tab).toBeInTheDocument();
         expect(tab.getAttribute('disabled')).toBeNull();
     });
@@ -35,7 +35,7 @@ describe('<Tabs.Trigger /> component', () => {
 
     it('disables the tab when the disabled property is set to true', () => {
         render(createTestComponent({ disabled: true }));
-        const tab = screen.getByRole('tab', { name: 'Tab 1' });
+        const tab = screen.getByRole('tab');
         expect(tab.getAttribute('disabled')).toEqual('');
     });
 });

--- a/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
+++ b/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
@@ -1,26 +1,27 @@
 import { render, screen } from '@testing-library/react';
 import { IconType } from '../../icon';
 import { Tabs, type ITabsTriggerProps } from '../../tabs';
+import { TabsList as RadixTabsList, Tabs as RadixTabsRoot } from '@radix-ui/react-tabs';
 
 describe('<Tabs.Trigger /> component', () => {
-    const createTestComponent = (tabs: ITabsTriggerProps[]) => (
-        <Tabs.Root defaultValue="1">
-            <Tabs.List>
-                {tabs.map((props, index) => (
-                    <Tabs.Trigger key={index} {...props} />
-                ))}
-            </Tabs.List>
-        </Tabs.Root>
-    );
+    const createTestComponent = (props?: Partial<ITabsTriggerProps>) => {
+        const completeProps: ITabsTriggerProps = {
+            label: 'Tab 1',
+            value: '1',
+            ...props,
+        };
+
+        return (
+            <RadixTabsRoot>
+                <RadixTabsList>
+                    <Tabs.Trigger {...completeProps} />
+                </RadixTabsList>
+            </RadixTabsRoot>
+        );
+    };
 
     it('renders a tab', () => {
-        render(
-            createTestComponent([
-                { label: 'Tab 1', value: '1' },
-                { label: 'Tab 2', value: '2' },
-            ]),
-        );
-
+        render(createTestComponent());
         const tab = screen.getByRole('tab', { name: 'Tab 1' });
         expect(tab).toBeInTheDocument();
         expect(tab.getAttribute('disabled')).toBeNull();
@@ -28,30 +29,13 @@ describe('<Tabs.Trigger /> component', () => {
 
     it('renders the icon when iconRight is provided', () => {
         const iconRight = IconType.BLOCKCHAIN_BLOCK;
-        render(
-            createTestComponent([
-                { label: 'Tab 1', value: '1', iconRight },
-                { label: 'Tab 2', value: '2' },
-            ]),
-        );
-
+        render(createTestComponent({ iconRight }));
         expect(screen.getByTestId(iconRight)).toBeInTheDocument();
     });
 
     it('disables the tab when the disabled property is set to true', () => {
-        render(
-            createTestComponent([
-                { label: 'Tab 1', value: '1', disabled: true },
-                { label: 'Tab 2', value: '2' },
-            ]),
-        );
-
+        render(createTestComponent({ disabled: true }));
         const tab = screen.getByRole('tab', { name: 'Tab 1' });
         expect(tab.getAttribute('disabled')).toEqual('');
-    });
-
-    it('does not render the Tabs.List or Tabs.Trigger in a single tab setup', () => {
-        render(createTestComponent([{ label: 'Tab 1', value: '1' }]));
-        expect(screen.queryByRole('tab')).not.toBeInTheDocument();
     });
 });

--- a/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
+++ b/src/core/components/tabs/tabsTrigger/tabsTrigger.test.tsx
@@ -1,7 +1,7 @@
+import { TabsList as RadixTabsList, Tabs as RadixTabsRoot } from '@radix-ui/react-tabs';
 import { render, screen } from '@testing-library/react';
 import { IconType } from '../../icon';
 import { Tabs, type ITabsTriggerProps } from '../../tabs';
-import { TabsList as RadixTabsList, Tabs as RadixTabsRoot } from '@radix-ui/react-tabs';
 
 describe('<Tabs.Trigger /> component', () => {
     const createTestComponent = (props?: Partial<ITabsTriggerProps>) => {


### PR DESCRIPTION
## Description

Update Tab component to not render the TabList when there is a single child

Task: [APP-3954](https://aragonassociation.atlassian.net/browse/APP-3954)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the `CHANGELOG.md` file after the [UPCOMING] title and before the latest version
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-3954]: https://aragonassociation.atlassian.net/browse/APP-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ