### PR TITLE
fix(APP-3977): Fix cancel button type of InputFileAvatar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix `InputNumber` core component so that it properly handles decimals when there is a default values set
+- Fix cancel button type of `InputFileAvatar` core component
 
 ## [1.0.67] - 2025-02-18
 

--- a/src/core/components/forms/inputFileAvatar/inputFileAvatar.tsx
+++ b/src/core/components/forms/inputFileAvatar/inputFileAvatar.tsx
@@ -137,6 +137,7 @@ export const InputFileAvatar: React.FC<IInputFileAvatarProps> = (props) => {
                                 'absolute -right-1 -top-1 cursor-pointer rounded-full bg-neutral-0 p-1 shadow-neutral',
                                 'focus:outline-none focus-visible:ring focus-visible:ring-primary focus-visible:ring-offset',
                             )}
+                            type="button"
                             aria-label="Cancel Selection"
                         >
                             <Icon icon={IconType.CLOSE} size="sm" />


### PR DESCRIPTION
## Description

- Set cancel button type to "button" to avoid form submit event

Task: [APP-3977](https://aragonassociation.atlassian.net/browse/APP-3977)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the `CHANGELOG.md` file after the [UPCOMING] title and before the latest version
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-3977]: https://aragonassociation.atlassian.net/browse/APP-3977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ