### PR TITLE
fix(APP-3978): Fix InputNumber component so that it properly handles decimals when there is a default values set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix InputNumber core component so that it properly handles decimals when there is a default values set
+
 ## [1.0.67] - 2025-02-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Fix InputNumber core component so that it properly handles decimals when there is a default values set
+- Fix `InputNumber` core component so that it properly handles decimals when there is a default values set
 
 ## [1.0.67] - 2025-02-18
 

--- a/src/core/components/forms/hooks/useNumberMask.test.ts
+++ b/src/core/components/forms/hooks/useNumberMask.test.ts
@@ -102,22 +102,4 @@ describe('useNumberMask hook', () => {
         onAccept?.('', maskValue);
         expect(onChange).toHaveBeenCalledWith(maskValue.unmaskedValue);
     });
-
-    it('updates the lazy option to force displaying the mask pattern when new value is not empty', () => {
-        const onChange = jest.fn();
-        const maskValue = { unmaskedValue: '1', updateOptions: jest.fn() } as unknown as InputMask;
-        renderHook(() => useNumberMask({ onChange }));
-        const { onAccept } = maskMock.mock.calls[0][1] ?? {};
-        onAccept?.('', maskValue);
-        expect(maskValue.updateOptions).toHaveBeenCalledWith({ lazy: false });
-    });
-
-    it('updates the lazy option to hide the mask pattern when new value is empty', () => {
-        const onChange = jest.fn();
-        const maskValue = { unmaskedValue: '', updateOptions: jest.fn() } as unknown as InputMask;
-        renderHook(() => useNumberMask({ onChange }));
-        const { onAccept } = maskMock.mock.calls[0][1] ?? {};
-        onAccept?.('', maskValue);
-        expect(maskValue.updateOptions).toHaveBeenCalledWith({ lazy: true });
-    });
 });

--- a/src/core/components/forms/hooks/useNumberMask.ts
+++ b/src/core/components/forms/hooks/useNumberMask.ts
@@ -45,14 +45,12 @@ export const useNumberMask = (props: IUseNumberMaskProps): IUseNumberMaskResult 
     const maskMin = min != null ? Number(min) : undefined;
 
     const handleMaskAccept = (_value: string, mask: InputMask<FactoryOpts>) => {
-        // Update the lazy option to display the suffix when the user is deleting the last digits of the input
-        const hideMask = mask.unmaskedValue === '';
-        mask.updateOptions({ lazy: hideMask });
         onChange?.(mask.unmaskedValue);
     };
 
     const result = useIMask<HTMLInputElement>(
         {
+            lazy: false,
             mask: numberMask,
             eager: true, // Displays eventual suffix on user input
             blocks: {


### PR DESCRIPTION
## Description

Fix `InputNumber` component so that it properly handles decimals when there is a default values set

<!--- Set the correct ticket number -->

Task: [APP-3978](https://aragonassociation.atlassian.net/browse/APP-3978)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Updated the `CHANGELOG.md` file after the [UPCOMING] title and before the latest version
- [x] Selected the correct base branch
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-3978]: https://aragonassociation.atlassian.net/browse/APP-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ