### PR TITLE
chore: Disable postinstall scripts by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.6.0.cjs
+
+enableScripts: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Update `NumberFormat.TOKEN_AMOUNT_SHORT` to round to two decimal places via new `smallValueThreshold` option
+- Disable `postinstall` scripts by default
 
 ## [1.0.68] - 2025-02-21
 


### PR DESCRIPTION
## Description

- Disable `postinstall` scripts by default

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the `CHANGELOG.md` file after the [UPCOMING] title and before the latest version
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing
