### PR TITLE
feat(APP-3652): Add variant property to ToggleGroup component, support XS size on Avatar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Update `<DaoDataListItem.Structure />` module component to support new `isExternal` property
+- Support `xs` size on `<Avatar />` core component
+- Add `variant` property to `<ToggleGroup />` core component to support space-between spacing
 
 ### Changed
 

--- a/src/core/components/avatars/avatar/avatar.tsx
+++ b/src/core/components/avatars/avatar/avatar.tsx
@@ -6,7 +6,7 @@ import { type ResponsiveAttribute, type ResponsiveAttributeClassMap } from '../.
 import { responsiveUtils } from '../../../utils';
 import { AvatarBase } from '../avatarBase';
 
-export type AvatarSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
 export interface IAvatarProps extends ComponentPropsWithoutRef<'img'> {
     /**
@@ -25,6 +25,14 @@ export interface IAvatarProps extends ComponentPropsWithoutRef<'img'> {
 }
 
 const responsiveSizeClasses: ResponsiveAttributeClassMap<AvatarSize> = {
+    xs: {
+        default: 'size-4',
+        sm: 'sm:size-4',
+        md: 'md:size-4',
+        lg: 'lg:size-4',
+        xl: 'xl:size-4',
+        '2xl': '2xl:size-4',
+    },
     sm: {
         default: 'size-6',
         sm: 'sm:size-6',

--- a/src/core/components/toggles/toggleGroup/toggleGroup.stories.tsx
+++ b/src/core/components/toggles/toggleGroup/toggleGroup.stories.tsx
@@ -29,6 +29,20 @@ export const Default: Story = {
 };
 
 /**
+ * Usage of the ToggleGroup component with space-between variant.
+ */
+export const SpaceBetween: Story = {
+    args: { variant: 'space-between' },
+    render: (props) => (
+        <ToggleGroup className="w-full" {...props}>
+            <Toggle value="default" label="Default" />
+            <Toggle value="optimistic" label="Optimistic" />
+            <Toggle value="timelock" label="Timelock" />
+        </ToggleGroup>
+    ),
+};
+
+/**
  * Controlled usage example of the ToggleGroup component.
  */
 export const Controlled: Story = {

--- a/src/core/components/toggles/toggleGroup/toggleGroup.tsx
+++ b/src/core/components/toggles/toggleGroup/toggleGroup.tsx
@@ -7,6 +7,11 @@ export type ToggleGroupValue<TMulti extends boolean> = TMulti extends true ? str
 export interface IToggleGroupBaseProps<TMulti extends boolean>
     extends Omit<ComponentProps<'div'>, 'value' | 'onChange' | 'defaultValue' | 'ref' | 'dir'> {
     /**
+     * Variant of the component defining the spacing between the toggle items.
+     * @default fixed
+     */
+    variant?: 'fixed' | 'space-between';
+    /**
      * Allows multiple toggles to be selected at the same time when set to true.
      */
     isMultiSelect: TMulti;
@@ -27,8 +32,14 @@ export interface IToggleGroupBaseProps<TMulti extends boolean>
 export type IToggleGroupProps = IToggleGroupBaseProps<true> | IToggleGroupBaseProps<false>;
 
 export const ToggleGroup = (props: IToggleGroupProps) => {
-    const { value, defaultValue, onChange, isMultiSelect, className, ...otherProps } = props;
-    const classes = classNames('flex flex-row flex-wrap gap-2 md:gap-3', className);
+    const { variant = 'fixed', value, defaultValue, onChange, isMultiSelect, className, ...otherProps } = props;
+
+    const classes = classNames(
+        'flex flex-row flex-wrap',
+        { 'gap-2 md:gap-3': variant === 'fixed' },
+        { 'justify-between gap-y-2': variant === 'space-between' },
+        className,
+    );
 
     if (isMultiSelect) {
         return (

--- a/src/modules/components/dao/daoAvatar/daoAvatar.tsx
+++ b/src/modules/components/dao/daoAvatar/daoAvatar.tsx
@@ -21,6 +21,14 @@ export interface IDaoAvatarProps extends Omit<IAvatarProps, 'fallback'> {
 }
 
 const responsiveSizeClasses: ResponsiveAttributeClassMap<AvatarSize> = {
+    xs: {
+        default: 'text-xs',
+        sm: 'sm:text-xs',
+        md: 'md:text-xs',
+        lg: 'lg:text-xs',
+        xl: 'xl:text-xs',
+        '2xl': '2xl:text-xs',
+    },
     sm: {
         default: 'text-sm',
         sm: 'sm:text-sm',


### PR DESCRIPTION
## Description

- Add `variant` property to `ToggleGroup` component to support "space-between" spacing
- Add XS size to Avatar core component

Task: [APP-3652](https://aragonassociation.atlassian.net/browse/APP-3652)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the `CHANGELOG.md` file after the [UPCOMING] title and before the latest version
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-3652]: https://aragonassociation.atlassian.net/browse/APP-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ