### PR TITLE
fix(APP-4115): Update 'support' logic for correct calc on ProposalVotingBreakdownToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `<ProposalVotingBreakdownToken />` 'support' logic to correctly include 'Yes' count without 'Abstain'
+
 ## [1.0.72] - 2025-03-25
 
 ### Added

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
@@ -72,8 +72,8 @@ describe('<ProposalVotingBreakdownToken /> component', () => {
         render(createTestComponent({ totalAbstain, totalNo, totalYes, supportThreshold, tokenSymbol }));
 
         const countableVotes = totalYes + totalNo;
-        const supportPercentage = countableVotes > 0 ? (totalYes / countableVotes) * 100 : 0;
-        const roundedSupportPercentage = Math.round(supportPercentage).toString();
+        const supportPercentage = (totalYes / countableVotes) * 100;
+        const roundedSupportPercentage = Math.round((totalYes / countableVotes) * 100).toString();
         const percentagePattern = new RegExp(`^${roundedSupportPercentage}(\\.\\d)?%$`);
 
         // eslint-disable-next-line testing-library/no-node-access

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
@@ -63,7 +63,7 @@ describe('<ProposalVotingBreakdownToken /> component', () => {
         });
     });
 
-    it('correctly renders the current winning option with support indicator', () => {
+    it('correctly renders the support percentage and indicator', () => {
         const totalYes = 2400;
         const totalNo = 5000;
         const totalAbstain = 2600;
@@ -71,22 +71,26 @@ describe('<ProposalVotingBreakdownToken /> component', () => {
         const tokenSymbol = 'TTT';
         render(createTestComponent({ totalAbstain, totalNo, totalYes, supportThreshold, tokenSymbol }));
 
+        const countableVotes = totalYes + totalNo;
+        const supportPercentage = countableVotes > 0 ? (totalYes / countableVotes) * 100 : 0;
+        const roundedSupportPercentage = Math.round(supportPercentage).toString();
+        const percentagePattern = new RegExp(`^${roundedSupportPercentage}(\\.\\d)?%$`);
+
         // eslint-disable-next-line testing-library/no-node-access
         const progressbarContainer = within(screen.getAllByRole('progressbar')[3].parentElement!);
+
         expect(screen.getByText('Support')).toBeInTheDocument();
-        expect(progressbarContainer.getByText('50%')).toBeInTheDocument();
-        expect(progressbarContainer.getByRole('progressbar').dataset.value).toEqual('50');
+        expect(progressbarContainer.getByText(percentagePattern)).toBeInTheDocument();
+        expect(progressbarContainer.getByRole('progressbar').dataset.value).toEqual(supportPercentage.toString());
         expect(progressbarContainer.getByTestId('progress-indicator').dataset.value).toEqual(
             supportThreshold.toString(),
         );
 
-        const formattedValue = formatterUtils.formatNumber(totalNo, { format: NumberFormat.GENERIC_SHORT })!;
-        const formattedTotal = formatterUtils.formatNumber(totalNo + totalYes + totalAbstain, {
-            format: NumberFormat.GENERIC_SHORT,
-        })!;
+        const formattedYes = formatterUtils.formatNumber(totalYes, { format: NumberFormat.GENERIC_SHORT })!;
+        const formattedCountable = formatterUtils.formatNumber(countableVotes, { format: NumberFormat.GENERIC_SHORT })!;
 
-        expect(progressbarContainer.getByText(formattedValue)).toBeInTheDocument();
-        expect(progressbarContainer.getByText(`of ${formattedTotal} ${tokenSymbol}`)).toBeInTheDocument();
+        expect(progressbarContainer.getByText(formattedYes)).toBeInTheDocument();
+        expect(progressbarContainer.getByText(`of ${formattedCountable} ${tokenSymbol}`)).toBeInTheDocument();
     });
 
     it('correctly renders the details for the minimum participation', () => {

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.test.tsx
@@ -73,8 +73,7 @@ describe('<ProposalVotingBreakdownToken /> component', () => {
 
         const countableVotes = totalYes + totalNo;
         const supportPercentage = (totalYes / countableVotes) * 100;
-        const roundedSupportPercentage = Math.round((totalYes / countableVotes) * 100).toString();
-        const percentagePattern = new RegExp(`^${roundedSupportPercentage}(\\.\\d)?%$`);
+        const percentagePattern = new RegExp(`^${Math.round(supportPercentage).toString()}(\\.\\d)?%$`);
 
         // eslint-disable-next-line testing-library/no-node-access
         const progressbarContainer = within(screen.getAllByRole('progressbar')[3].parentElement!);

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
@@ -56,13 +56,9 @@ export const ProposalVotingBreakdownToken: React.FC<IProposalVotingBreakdownToke
     const totalAbstainNumber = Number(totalAbstain);
 
     const optionValues = [
-        { name: copy.proposalVotingBreakdownToken.option.yes, value: Number(totalYesNumber), variant: 'success' },
-        {
-            name: copy.proposalVotingBreakdownToken.option.abstain,
-            value: Number(totalAbstainNumber),
-            variant: 'neutral',
-        },
-        { name: copy.proposalVotingBreakdownToken.option.no, value: Number(totalNoNumber), variant: 'critical' },
+        { name: copy.proposalVotingBreakdownToken.option.yes, value: totalYesNumber, variant: 'success' },
+        { name: copy.proposalVotingBreakdownToken.option.abstain, value: totalAbstainNumber, variant: 'neutral' },
+        { name: copy.proposalVotingBreakdownToken.option.no, value: totalNoNumber, variant: 'critical' },
     ] as const;
 
     const totalSupplyNumber = Number(tokenTotalSupply);

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
@@ -109,7 +109,7 @@ export const ProposalVotingBreakdownToken: React.FC<IProposalVotingBreakdownToke
                     description={{
                         value: formattedTotalYes,
                         text: copy.proposalVotingBreakdownToken.support.description(
-                            `${formattedCountableVotes!.toString()} ${tokenSymbol}`,
+                            `${formattedCountableVotes!} ${tokenSymbol}`,
                         ),
                     }}
                     showPercentage={true}

--- a/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingBreakdownToken/proposalVotingBreakdownToken.tsx
@@ -51,10 +51,18 @@ export const ProposalVotingBreakdownToken: React.FC<IProposalVotingBreakdownToke
 
     const { copy } = useGukModulesContext();
 
+    const totalYesNumber = Number(totalYes);
+    const totalNoNumber = Number(totalNo);
+    const totalAbstainNumber = Number(totalAbstain);
+
     const optionValues = [
-        { name: copy.proposalVotingBreakdownToken.option.yes, value: Number(totalYes), variant: 'success' },
-        { name: copy.proposalVotingBreakdownToken.option.abstain, value: Number(totalAbstain), variant: 'neutral' },
-        { name: copy.proposalVotingBreakdownToken.option.no, value: Number(totalNo), variant: 'critical' },
+        { name: copy.proposalVotingBreakdownToken.option.yes, value: Number(totalYesNumber), variant: 'success' },
+        {
+            name: copy.proposalVotingBreakdownToken.option.abstain,
+            value: Number(totalAbstainNumber),
+            variant: 'neutral',
+        },
+        { name: copy.proposalVotingBreakdownToken.option.no, value: Number(totalNoNumber), variant: 'critical' },
     ] as const;
 
     const totalSupplyNumber = Number(tokenTotalSupply);
@@ -69,13 +77,13 @@ export const ProposalVotingBreakdownToken: React.FC<IProposalVotingBreakdownToke
         format: NumberFormat.GENERIC_SHORT,
     })!;
 
-    const winningOption = Math.max(...optionValues.map((option) => option.value));
-    const winningOptionPercentage = totalVotes > 0 ? (winningOption / totalVotes) * 100 : 0;
-    const formattedWinningOption = formatterUtils.formatNumber(winningOption, { format: NumberFormat.GENERIC_SHORT });
-
+    const countableVotes = totalYesNumber + totalNoNumber;
+    const supportPercentage = countableVotes > 0 ? (totalYesNumber / countableVotes) * 100 : 0;
+    const formattedCountableVotes = formatterUtils.formatNumber(countableVotes, { format: NumberFormat.GENERIC_SHORT });
+    const formattedTotalYes = formatterUtils.formatNumber(totalYesNumber, { format: NumberFormat.GENERIC_SHORT });
     const currentParticipationPercentage = (totalVotes / minParticipationToken) * 100;
 
-    const supportReached = winningOptionPercentage >= supportThreshold;
+    const supportReached = supportPercentage >= supportThreshold;
     const minParticipationReached = currentParticipationPercentage >= minParticipation;
 
     return (
@@ -101,11 +109,11 @@ export const ProposalVotingBreakdownToken: React.FC<IProposalVotingBreakdownToke
             <ProposalVotingProgress.Container direction="col">
                 <ProposalVotingProgress.Item
                     name={copy.proposalVotingBreakdownToken.support.name}
-                    value={winningOptionPercentage}
+                    value={supportPercentage}
                     description={{
-                        value: formattedWinningOption,
+                        value: formattedTotalYes,
                         text: copy.proposalVotingBreakdownToken.support.description(
-                            `${formattedTotalVotes} ${tokenSymbol}`,
+                            `${formattedCountableVotes!.toString()} ${tokenSymbol}`,
                         ),
                     }}
                     showPercentage={true}


### PR DESCRIPTION
## Description

Breakdown now correctly calculates and outputs support based on `Yes / (Yes + No)`

Task: [APP-4115](https://aragonassociation.atlassian.net/browse/APP-4115)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Updated the `CHANGELOG.md` file after the [UPCOMING] title and before the latest version
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-4115]: https://aragonassociation.atlassian.net/browse/APP-4115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ