### PR TITLE
fix(APP-3610): Remove outline from dialog to prevent unwanted styling when focus is applied

### DIFF
--- a/.changeset/good-badgers-visit.md
+++ b/.changeset/good-badgers-visit.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': patch
+---
+
+Add outline none to dialog to fix unwanted styling when user focuses inside

--- a/src/core/components/dialogs/dialog/dialogRoot/dialogRoot.tsx
+++ b/src/core/components/dialogs/dialog/dialogRoot/dialogRoot.tsx
@@ -37,7 +37,7 @@ export const DialogRoot: React.FC<IDialogRootProps> = (props) => {
     );
 
     const containerClassNames = classNames(
-        'fixed inset-x-2 bottom-2 mx-auto max-h-[calc(100vh-80px)] md:inset-x-6 md:bottom-6 lg:bottom-auto lg:top-12 lg:max-h-[calc(100vh-200px)]',
+        'fixed inset-x-2 bottom-2 mx-auto max-h-[calc(100vh-80px)] focus:outline-none md:inset-x-6 md:bottom-6 lg:bottom-auto lg:top-12 lg:max-h-[calc(100vh-200px)]',
         'flex flex-col rounded-xl border border-neutral-100 bg-neutral-0 shadow-neutral-md',
         'z-[var(--guk-dialog-content-z-index)]',
         sizeToClassNames[size],


### PR DESCRIPTION
## Description

- Remove outline from dialog to prevent unwanted styling when focus is applied

Worth noting that there are some accessibility considerations here.

Task: [APP-3610](https://aragonassociation.atlassian.net/browse/APP-3610)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-3610]: https://aragonassociation.atlassian.net/browse/APP-3610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ