### PR TITLE
feat(APP-3488): Prevent default onClick/onSelect behaviour for Dropdown items when disabled

### DIFF
--- a/.changeset/sharp-carrots-search.md
+++ b/.changeset/sharp-carrots-search.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': patch
+---
+
+Implement correct styling and iteractivity for disabled items in core `DropdowItem` component

--- a/.changeset/sharp-carrots-search.md
+++ b/.changeset/sharp-carrots-search.md
@@ -2,4 +2,4 @@
 '@aragon/gov-ui-kit': patch
 ---
 
-Prevent default behaviour of disabled items in core `DropdownItem` component
+Fix `DropdownItem` core component to prevent default click behaviour when disabled

--- a/.changeset/sharp-carrots-search.md
+++ b/.changeset/sharp-carrots-search.md
@@ -2,4 +2,4 @@
 '@aragon/gov-ui-kit': patch
 ---
 
-Implement correct styling and iteractivity for disabled items in core `DropdowItem` component
+Prevent default behaviour of disabled items in core `DropdownItem` component

--- a/src/core/components/dropdown/dropdownItem/dropdownItem.tsx
+++ b/src/core/components/dropdown/dropdownItem/dropdownItem.tsx
@@ -70,7 +70,7 @@ export const DropdownItem: React.FC<IDropdownItemProps> = (props) => {
             className={classNames(
                 'flex items-center gap-3 px-4 py-3', // Layout
                 'cursor-pointer rounded-xl text-base leading-tight focus-visible:outline-none', // Style
-                'data-[disabled]:cursor-default data-[disabled]:bg-neutral-0 data-[disabled]:text-neutral-300', // Disabled
+                'data-[disabled]:pointer-events-none data-[disabled]:cursor-default data-[disabled]:bg-neutral-0 data-[disabled]:text-neutral-300', // Disabled
                 { 'bg-neutral-0 text-neutral-500': !selected && !disabled }, // Not selected
                 { 'bg-neutral-50 text-neutral-800': selected && !disabled }, // Selected
                 { 'hover:bg-neutral-50 hover:text-neutral-800': !disabled }, // Hover


### PR DESCRIPTION
## Description

Prevent default onClick/onSelect behaviour for Dropdown items when disabled.

Task: [APP-3488](https://aragonassociation.atlassian.net/browse/APP-3488)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing


[APP-3488]: https://aragonassociation.atlassian.net/browse/APP-3488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ