### PR TITLE
feat(APP-4205): Implement 'link' prop and component within DefinitionListItem

### DIFF
--- a/.changeset/loud-garlics-wear.md
+++ b/.changeset/loud-garlics-wear.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': patch
+---
+
+Implement 'link' prop and component within `<DefinitionList.Item />`

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.stories.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.stories.tsx
@@ -52,8 +52,8 @@ export const WithLink: Story = {
         link: {
             href: 'https://www.example.com',
         },
+        children: 'Homepage',
     },
-    render: (props: IDefinitionListItemProps) => <DefinitionList.Item {...props}>Homepage</DefinitionList.Item>,
 };
 
 /**

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.stories.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.stories.tsx
@@ -46,6 +46,16 @@ export const WithComponent: Story = {
     ),
 };
 
+export const WithLink: Story = {
+    args: {
+        term: 'Website',
+        link: {
+            href: 'https://www.example.com',
+        },
+    },
+    render: (props: IDefinitionListItemProps) => <DefinitionList.Item {...props}>Homepage</DefinitionList.Item>,
+};
+
 /**
  * Usage of the DefinitionList.Item component with a truncated long string.
  */

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.test.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.test.tsx
@@ -28,4 +28,21 @@ describe('<DefinitionList.Item /> component', () => {
 
         expect(description).toHaveTextContent(children);
     });
+
+    it('renders a link when href is provided', () => {
+        const href = 'https://example.com';
+        const children = 'Click Here';
+        render(
+            createTestComponent({
+                link: {
+                    href,
+                },
+                children,
+            }),
+        );
+
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('href', href);
+        expect(link).toHaveTextContent(children);
+    });
 });

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.test.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.test.tsx
@@ -32,14 +32,7 @@ describe('<DefinitionList.Item /> component', () => {
     it('renders a link when href is provided', () => {
         const href = 'https://example.com';
         const children = 'Click Here';
-        render(
-            createTestComponent({
-                link: {
-                    href,
-                },
-                children,
-            }),
-        );
+        render(createTestComponent({ link: { href }, children }));
 
         const link = screen.getByRole('link');
         expect(link).toHaveAttribute('href', href);

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
@@ -17,12 +17,7 @@ export interface IDefinitionListItemProps extends ComponentPropsWithRef<'div'> {
 export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) => {
     const { term, link, children, className, ...otherProps } = props;
 
-    const {
-        href,
-        target = '_blank',
-        iconRight = IconType.LINK_EXTERNAL,
-        ...otherLinkProps
-    } = link ?? {};
+    const { href, target = '_blank', iconRight = IconType.LINK_EXTERNAL, ...otherLinkProps } = link ?? {};
 
     return (
         <div
@@ -36,12 +31,7 @@ export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) =>
             {href == null && <dd className="min-w-0 leading-tight text-neutral-500">{children}</dd>}
             {href != null && (
                 <dd className="min-w-0 leading-tight text-neutral-500">
-                    <Link
-                        href={href}
-                        target={target}
-                        iconRight={iconRight}
-                        {...otherLinkProps}
-                    >
+                    <Link href={href} target={target} iconRight={iconRight} {...otherLinkProps}>
                         {children}
                     </Link>
                 </dd>

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
@@ -1,15 +1,23 @@
 import classNames from 'classnames';
 import { type ComponentPropsWithRef } from 'react';
+import { IconType } from '../../icon';
+import { Link, type ILinkProps } from '../../link';
 
 export interface IDefinitionListItemProps extends ComponentPropsWithRef<'div'> {
     /**
      * The term to be displayed in the definition list item.
      */
     term: string;
+    /**
+     * The materials for a Link component if necessary.
+     */
+    link?: ILinkProps;
 }
 
 export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) => {
-    const { term, children, className, ...otherProps } = props;
+    const { term, link, children, className, ...otherProps } = props;
+
+    const { href, target = '_blank', iconRight = IconType.LINK_EXTERNAL, ...otherLinkProps } = link ?? {};
 
     return (
         <div
@@ -20,7 +28,14 @@ export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) =>
             {...otherProps}
         >
             <dt className="line-clamp-1 leading-tight text-neutral-800 md:line-clamp-none">{term}</dt>
-            <dd className="min-w-0 leading-tight text-neutral-500">{children}</dd>
+            {href == null && <dd className="min-w-0 leading-tight text-neutral-500">{children}</dd>}
+            {href != null && (
+                <dd className="min-w-0 leading-tight text-neutral-500">
+                    <Link href={href} target={target} iconRight={iconRight} {...otherLinkProps}>
+                        {children}
+                    </Link>
+                </dd>
+            )}
         </div>
     );
 };

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
@@ -17,7 +17,13 @@ export interface IDefinitionListItemProps extends ComponentPropsWithRef<'div'> {
 export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) => {
     const { term, link, children, className, ...otherProps } = props;
 
-    const { href, target = '_blank', iconRight = IconType.LINK_EXTERNAL, ...otherLinkProps } = link ?? {};
+    const {
+        href,
+        target = '_blank',
+        iconRight = IconType.LINK_EXTERNAL,
+        textClassName = 'first-letter:capitalize',
+        ...otherLinkProps
+    } = link ?? {};
 
     return (
         <div
@@ -31,7 +37,13 @@ export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) =>
             {href == null && <dd className="min-w-0 leading-tight text-neutral-500">{children}</dd>}
             {href != null && (
                 <dd className="min-w-0 leading-tight text-neutral-500">
-                    <Link href={href} target={target} iconRight={iconRight} {...otherLinkProps}>
+                    <Link
+                        href={href}
+                        target={target}
+                        iconRight={iconRight}
+                        textClassName={textClassName}
+                        {...otherLinkProps}
+                    >
                         {children}
                     </Link>
                 </dd>

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
@@ -30,7 +30,7 @@ export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) =>
             <dt className="line-clamp-1 leading-tight text-neutral-800 md:line-clamp-none">{term}</dt>
             <dd className="min-w-0 leading-tight text-neutral-500">
                 {href == null && children}
-                {href != null && children == null && (
+                {href != null && (
                     <Link href={href} target={target} iconRight={iconRight} {...otherLinkProps}>
                         {children}
                     </Link>

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
@@ -28,14 +28,14 @@ export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) =>
             {...otherProps}
         >
             <dt className="line-clamp-1 leading-tight text-neutral-800 md:line-clamp-none">{term}</dt>
-            {href == null && <dd className="min-w-0 leading-tight text-neutral-500">{children}</dd>}
-            {href != null && (
-                <dd className="min-w-0 leading-tight text-neutral-500">
+            <dd className="min-w-0 leading-tight text-neutral-500">
+                {href == null && children}
+                {href != null && children == null && (
                     <Link href={href} target={target} iconRight={iconRight} {...otherLinkProps}>
                         {children}
                     </Link>
-                </dd>
-            )}
+                )}
+            </dd>
         </div>
     );
 };

--- a/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
+++ b/src/core/components/definitionList/definitionListItem/definitionListItem.tsx
@@ -21,7 +21,6 @@ export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) =>
         href,
         target = '_blank',
         iconRight = IconType.LINK_EXTERNAL,
-        textClassName = 'first-letter:capitalize',
         ...otherLinkProps
     } = link ?? {};
 
@@ -41,7 +40,6 @@ export const DefinitionListItem: React.FC<IDefinitionListItemProps> = (props) =>
                         href={href}
                         target={target}
                         iconRight={iconRight}
-                        textClassName={textClassName}
                         {...otherLinkProps}
                     >
                         {children}

--- a/src/modules/assets/copy/modulesCopy.ts
+++ b/src/modules/assets/copy/modulesCopy.ts
@@ -155,6 +155,8 @@ export const modulesCopy = {
     proposalVotingDetails: {
         voting: 'Voting',
         governance: 'Governance',
+        starts: 'Starts',
+        expires: 'Expires',
     },
     proposalVotingStage: {
         stage: (index: number) => `Stage ${index.toString()}`,

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeSettings/index.ts
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeSettings/index.ts
@@ -2,6 +2,5 @@ export { ProposalActionChangeSettings } from './proposalActionChangeSettings';
 export type {
     IProposalActionChangeSettings,
     IProposalActionChangeSettingsProps,
-    IProposalActionChangeSettingsSetting,
 } from './proposalActionChangeSettings.api';
 export * from './proposalActionChangeSettings.testUtils';

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeSettings/proposalActionChangeSettings.api.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeSettings/proposalActionChangeSettings.api.tsx
@@ -1,25 +1,15 @@
+import type { IDefinitionSetting } from '../../../../../types/definitionSetting';
 import type { IProposalAction, IProposalActionComponentProps } from '../../proposalActionsDefinitions';
-
-export interface IProposalActionChangeSettingsSetting {
-    /**
-     * The term of the setting.
-     */
-    term: string;
-    /**
-     * The definition of the setting.
-     */
-    definition: string | number;
-}
 
 export interface IProposalActionChangeSettings extends IProposalAction {
     /**
      * The settings that are proposed to be changed
      */
-    proposedSettings: IProposalActionChangeSettingsSetting[];
+    proposedSettings: IDefinitionSetting[];
     /**
      * The settings that are currently in place.
      */
-    existingSettings: IProposalActionChangeSettingsSetting[];
+    existingSettings: IDefinitionSetting[];
 }
 
 export interface IProposalActionChangeSettingsProps

--- a/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeSettings/proposalActionChangeSettings.api.tsx
+++ b/src/modules/components/proposal/proposalActions/proposalActionsList/proposalActionChangeSettings/proposalActionChangeSettings.api.tsx
@@ -1,4 +1,4 @@
-import type { IDefinitionSetting } from '../../../../../types/definitionSetting';
+import type { IDefinitionSetting } from '../../../../../types';
 import type { IProposalAction, IProposalActionComponentProps } from '../../proposalActionsDefinitions';
 
 export interface IProposalActionChangeSettings extends IProposalAction {

--- a/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { DateTime, Settings } from 'luxon';
 import { Tabs } from '../../../../../core';
-import type { IDefinitionSetting } from '../../../../types/definitionSetting';
+import type { IDefinitionSetting } from '../../../../types';
 import { ProposalVotingTab } from '../proposalVotingDefinitions';
 import { type IProposalVotingStageContext, ProposalVotingStageContextProvider } from '../proposalVotingStageContext';
 import { type IProposalVotingDetailsProps, ProposalVotingDetails } from './proposalVotingDetails';

--- a/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.test.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.test.tsx
@@ -1,13 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { DateTime, Settings } from 'luxon';
 import { Tabs } from '../../../../../core';
+import type { IDefinitionSetting } from '../../../../types/definitionSetting';
 import { ProposalVotingTab } from '../proposalVotingDefinitions';
 import { type IProposalVotingStageContext, ProposalVotingStageContextProvider } from '../proposalVotingStageContext';
-import {
-    type IProposalVotingDetailsProps,
-    type IProposalVotingDetailsSetting,
-    ProposalVotingDetails,
-} from './proposalVotingDetails';
+import { type IProposalVotingDetailsProps, ProposalVotingDetails } from './proposalVotingDetails';
 
 describe('<ProposalVotingDetails /> component', () => {
     const originalNow = Settings.now;
@@ -73,7 +70,7 @@ describe('<ProposalVotingDetails /> component', () => {
     });
 
     it('does not render the governance text when settings array is empty', () => {
-        const settings: IProposalVotingDetailsSetting[] = [];
+        const settings: IDefinitionSetting[] = [];
         render(createTestComponent({ settings }));
         expect(screen.queryByText('Governance')).not.toBeInTheDocument();
     });

--- a/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
@@ -1,5 +1,13 @@
 import classNames from 'classnames';
-import { DateFormat, DefinitionList, formatterUtils, Heading, type ITabsContentProps, Tabs } from '../../../../../core';
+import {
+    DateFormat,
+    DefinitionList,
+    formatterUtils,
+    Heading,
+    type ILinkProps,
+    type ITabsContentProps,
+    Tabs,
+} from '../../../../../core';
 import { useGukModulesContext } from '../../../gukModulesProvider';
 import { ProposalVotingTab } from '../proposalVotingDefinitions';
 import { useProposalVotingStageContext } from '../proposalVotingStageContext';
@@ -13,6 +21,10 @@ export interface IProposalVotingDetailsSetting {
      * Value of the setting.
      */
     definition: string;
+    /**
+     * Optional link for the setting.
+     */
+    link?: ILinkProps;
 }
 
 export interface IProposalVotingDetailsProps extends Omit<ITabsContentProps, 'value'> {
@@ -41,10 +53,10 @@ export const ProposalVotingDetails: React.FC<IProposalVotingDetailsProps> = (pro
         >
             <Heading size="h3">{copy.proposalVotingDetails.voting}</Heading>
             <DefinitionList.Container>
-                <DefinitionList.Item term="Starts">
+                <DefinitionList.Item term={copy.proposalVotingDetails.starts}>
                     <p className="text-neutral-500 first-letter:capitalize">{formattedStartDate}</p>
                 </DefinitionList.Item>
-                <DefinitionList.Item term="Expires">
+                <DefinitionList.Item term={copy.proposalVotingDetails.expires}>
                     <p className="text-neutral-500 first-letter:capitalize">{formattedEndDate}</p>
                 </DefinitionList.Item>
             </DefinitionList.Container>
@@ -52,8 +64,8 @@ export const ProposalVotingDetails: React.FC<IProposalVotingDetailsProps> = (pro
                 <>
                     <Heading size="h3">{copy.proposalVotingDetails.governance}</Heading>
                     <DefinitionList.Container>
-                        {settings.map(({ term, definition }) => (
-                            <DefinitionList.Item key={term} term={term}>
+                        {settings.map(({ term, definition, link }) => (
+                            <DefinitionList.Item key={term} term={term} link={link}>
                                 <p className="text-neutral-500">{definition}</p>
                             </DefinitionList.Item>
                         ))}

--- a/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
@@ -1,37 +1,15 @@
 import classNames from 'classnames';
-import {
-    DateFormat,
-    DefinitionList,
-    formatterUtils,
-    Heading,
-    type ILinkProps,
-    type ITabsContentProps,
-    Tabs,
-} from '../../../../../core';
+import { DateFormat, DefinitionList, formatterUtils, Heading, type ITabsContentProps, Tabs } from '../../../../../core';
+import type { IDefinitionSetting } from '../../../../types/definitionSetting';
 import { useGukModulesContext } from '../../../gukModulesProvider';
 import { ProposalVotingTab } from '../proposalVotingDefinitions';
 import { useProposalVotingStageContext } from '../proposalVotingStageContext';
-
-export interface IProposalVotingDetailsSetting {
-    /**
-     * Term of the setting.
-     */
-    term: string;
-    /**
-     * Value of the setting.
-     */
-    definition: string;
-    /**
-     * Optional link for the setting.
-     */
-    link?: ILinkProps;
-}
 
 export interface IProposalVotingDetailsProps extends Omit<ITabsContentProps, 'value'> {
     /**
      * Governance settings displayed on the details tab.
      */
-    settings?: IProposalVotingDetailsSetting[];
+    settings?: IDefinitionSetting[];
 }
 
 export const ProposalVotingDetails: React.FC<IProposalVotingDetailsProps> = (props) => {

--- a/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { DateFormat, DefinitionList, formatterUtils, Heading, type ITabsContentProps, Tabs } from '../../../../../core';
-import type { IDefinitionSetting } from '../../../../types/definitionSetting';
+import type { IDefinitionSetting } from '../../../../types';
 import { useGukModulesContext } from '../../../gukModulesProvider';
 import { ProposalVotingTab } from '../proposalVotingDefinitions';
 import { useProposalVotingStageContext } from '../proposalVotingStageContext';

--- a/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
+++ b/src/modules/components/proposal/proposalVoting/proposalVotingDetails/proposalVotingDetails.tsx
@@ -66,7 +66,7 @@ export const ProposalVotingDetails: React.FC<IProposalVotingDetailsProps> = (pro
                     <DefinitionList.Container>
                         {settings.map(({ term, definition, link }) => (
                             <DefinitionList.Item key={term} term={term} link={link}>
-                                <p className="text-neutral-500">{definition}</p>
+                                {definition}
                             </DefinitionList.Item>
                         ))}
                     </DefinitionList.Container>

--- a/src/modules/types/definitionSetting.ts
+++ b/src/modules/types/definitionSetting.ts
@@ -1,0 +1,8 @@
+import type { IDefinitionListItemProps } from "../../core";
+
+export interface IDefinitionSetting extends Pick<IDefinitionListItemProps, 'term' | 'link'> {
+    /**
+     * The definition for the term in the list item.
+     */
+    definition?: string;
+}

--- a/src/modules/types/definitionSetting.ts
+++ b/src/modules/types/definitionSetting.ts
@@ -1,4 +1,4 @@
-import type { IDefinitionListItemProps } from "../../core";
+import type { IDefinitionListItemProps } from '../../core';
 
 export interface IDefinitionSetting extends Pick<IDefinitionListItemProps, 'term' | 'link'> {
     /**

--- a/src/modules/types/index.ts
+++ b/src/modules/types/index.ts
@@ -1,2 +1,3 @@
 export type * from './compositeAddress';
+export type * from './definitionSetting';
 export type * from './web3ComponentConfig';


### PR DESCRIPTION
## Description

Implement 'link' prop and component within `<DefinitionList.Item />`

Task: [APP-4205](https://aragonassociation.atlassian.net/browse/APP-4205)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [x] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [x] Confirmed that changes follow the code style guidelines of this project


[APP-4205]: https://aragonassociation.atlassian.net/browse/APP-4205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ