### PR TITLE
feat: Update DocumentParser core component to expose immediatelyRender prop

### DIFF
--- a/.changeset/warm-plants-talk.md
+++ b/.changeset/warm-plants-talk.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': minor
+---
+
+Update DocumentParser core component to expose immediatelyRender prop

--- a/src/core/components/documentParser/documentParser.tsx
+++ b/src/core/components/documentParser/documentParser.tsx
@@ -12,40 +12,32 @@ export interface IDocumentParserProps extends ComponentPropsWithoutRef<'div'> {
      * The stringified document of Markdown or HTML to parse into a styled output.
      */
     document: string;
+    /**
+     * Whether to render the editor on the first render or not.
+     */
+    immediatelyRender?: boolean;
 }
 
 export const DocumentParser: React.FC<IDocumentParserProps> = (props) => {
-    const { children, className, document, ...otherProps } = props;
+    const { children, className, document, immediatelyRender, ...otherProps } = props;
 
     const sanitizeDocument = (document: string): string => {
-        return sanitizeHtml(document, {
-            allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'del']),
-            allowedAttributes: {
-                ...sanitizeHtml.defaults.allowedAttributes,
-                img: ['src', 'alt'],
-                a: ['href', 'title'],
-            },
-            disallowedTagsMode: 'recursiveEscape',
-        });
+        const allowedTags = sanitizeHtml.defaults.allowedTags.concat(['img', 'del']);
+        const disallowedTagsMode = 'recursiveEscape';
+        const allowedAttributes = {
+            ...sanitizeHtml.defaults.allowedAttributes,
+            img: ['src', 'alt'],
+            a: ['href', 'title'],
+        };
+
+        return sanitizeHtml(document, { allowedTags, allowedAttributes, disallowedTagsMode });
     };
 
-    const parser = useEditor({
-        editable: false,
-        extensions: [
-            StarterKit,
-            Image,
-            Markdown,
-            TipTapLink.configure({
-                openOnClick: false,
-            }),
-        ],
-        content: sanitizeDocument(document),
-    });
+    const extensions = [StarterKit, Image, Markdown, TipTapLink.configure({ openOnClick: false })];
+    const parser = useEditor({ editable: false, immediatelyRender, extensions, content: sanitizeDocument(document) });
 
     useEffect(() => {
-        if (parser) {
-            parser.commands.setContent(sanitizeDocument(document), true);
-        }
+        parser?.commands.setContent(sanitizeDocument(document), true);
     }, [document, parser]);
 
     return (


### PR DESCRIPTION
## Description

- Expose the `immediatelyRender` property on the `DocumentParser` component for SSR usage as already done on the `TextAreaRichText` component

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
