### PR TITLE
fix(APP-4405): Fix "asChild" variant style of SmartContractFunction data list component

### DIFF
--- a/.changeset/beige-chefs-behave.md
+++ b/.changeset/beige-chefs-behave.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': patch
+---
+
+Fix `asChild` variant style of SmartContractFunction data list component

--- a/src/modules/components/smartContract/smartContractFunctionDataListItem/smartContractFunctionDataListItemSkeleton/smartContractFunctionDataListItemSkeleton.tsx
+++ b/src/modules/components/smartContract/smartContractFunctionDataListItem/smartContractFunctionDataListItemSkeleton/smartContractFunctionDataListItemSkeleton.tsx
@@ -13,16 +13,17 @@ export const SmartContractFunctionDataListItemSkeleton: React.FC<ISmartContractF
 ) => {
     const { className, asChild, ...otherProps } = props;
 
-    const containerClasses = asChild
-        ? ' border-none shadow-none'
-        : 'border-neutral-0 flex min-h-[67.5px] w-full flex-col gap-3 py-4 md:min-h-[88.5px]';
-
     return (
         <DataList.Item
             tabIndex={!asChild ? 0 : undefined}
             aria-busy={!asChild ? true : undefined}
             aria-label={!asChild ? 'loading' : undefined}
-            className={classNames(containerClasses, className)}
+            className={classNames(
+                'flex w-full flex-col gap-3 py-4',
+                { 'min-h-[67.5px] md:min-h-[88.5px]': !asChild },
+                { 'min-h-[35.5px] border-none !p-0 shadow-none md:min-h-[56.5px]': asChild },
+                className,
+            )}
             {...otherProps}
         >
             <div className="flex w-1/2 md:w-1/3">

--- a/src/modules/components/smartContract/smartContractFunctionDataListItem/smartContractFunctionDataListItemStructure/smartContractFunctionDataListItemStructure.tsx
+++ b/src/modules/components/smartContract/smartContractFunctionDataListItem/smartContractFunctionDataListItemStructure/smartContractFunctionDataListItemStructure.tsx
@@ -88,7 +88,7 @@ export const SmartContractFunctionDataListItemStructure: React.FC<ISmartContract
     const displayWarningFeedback = displayWarning || !hasVerifiedNames;
 
     const containerClassName = asChild
-        ? 'p-0 border-none shadow-none'
+        ? '!p-0 border-none shadow-none'
         : 'flex items-center justify-between gap-x-3 py-3 md:gap-x-4 md:py-5';
 
     const functionLabelStyle = displayWarningFeedback ? 'text-warning-800' : 'text-neutral-800';


### PR DESCRIPTION
## Description

- Correctly set spacings of `SmartContractFunction` data list component when used with the `asChild` variant (e.g. on the `ProposalAction` component)

<!--- Set the correct ticket number -->

Task: [APP-4405](https://aragonassociation.atlassian.net/browse/APP-4405)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
