### PR TITLE
WIP feat: Expose additional EmptyState props on DataListContainer 

### DIFF
--- a/.changeset/honest-showers-stop.md
+++ b/.changeset/honest-showers-stop.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': minor
+---
+
+Expose additional props on DataListContainer for more control over EmptyState usage

--- a/src/core/components/dataList/dataListContainer/dataListContainer.tsx
+++ b/src/core/components/dataList/dataListContainer/dataListContainer.tsx
@@ -6,7 +6,10 @@ import { useDataListContext } from '../dataListContext';
 import { DataListContainerSkeletonLoader } from './dataListContainerSkeletonLoader';
 
 export interface IDataListContainerState
-    extends Pick<IEmptyStateProps, 'heading' | 'description' | 'primaryButton' | 'secondaryButton'> {}
+    extends Pick<
+        IEmptyStateProps,
+        'heading' | 'description' | 'objectIllustration' | 'isStacked' | 'primaryButton' | 'secondaryButton'
+    > {}
 
 export interface IDataListContainerProps extends ComponentProps<'div'> {
     /**
@@ -81,13 +84,25 @@ export const DataListContainer: React.FC<IDataListContainerProps> = (props) => {
         >
             {displayLoadingElements && loadingItems.map((_value, index) => <SkeletonLoader key={index} />)}
             {isError && errorState != null && (
-                <CardEmptyState objectIllustration={{ object: 'ERROR' }} {...errorState} />
+                <CardEmptyState
+                    isStacked={errorState.isStacked}
+                    objectIllustration={errorState.objectIllustration ?? { object: 'ERROR' }}
+                    {...errorState}
+                />
             )}
             {isEmpty && emptyState != null && (
-                <CardEmptyState objectIllustration={{ object: 'ERROR' }} {...emptyState} />
+                <CardEmptyState
+                    isStacked={emptyState.isStacked}
+                    objectIllustration={emptyState.objectIllustration ?? { object: 'ERROR' }}
+                    {...emptyState}
+                />
             )}
             {isEmptyFiltered && emptyFilteredState != null && (
-                <CardEmptyState objectIllustration={{ object: 'NOT_FOUND' }} {...emptyFilteredState} />
+                <CardEmptyState
+                    isStacked={emptyFilteredState.isStacked}
+                    objectIllustration={emptyFilteredState.objectIllustration ?? { object: 'NOT_FOUND' }}
+                    {...emptyFilteredState}
+                />
             )}
             {displayItems && paginatedChildren}
         </div>


### PR DESCRIPTION
## Description

Allows for custom illustration and is stacked of EmptyState component for all states of DataList

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Developer Checklist:

- [ ] Manually smoke tested the functionality locally
- [ ] Confirmed there are no new warnings or errors in the browser console
- [ ] Made the corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [ ] Confirmed there are no new warnings on automated tests
- [ ] Selected the correct base branch
- [ ] Commented the code in hard-to-understand areas
- [ ] Followed the code style guidelines of this project
- [ ] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [ ] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
