### PR TITLE
fix: Fix TextAreaRichText and DocumentParser components after tiptap migration

### DIFF
--- a/.changeset/honest-mirrors-win.md
+++ b/.changeset/honest-mirrors-win.md
@@ -1,0 +1,5 @@
+---
+'@aragon/gov-ui-kit': patch
+---
+
+Fix TextAreaRichText and DocumentParser components after tiptap migration

--- a/src/core/components/documentParser/documentParser.test.tsx
+++ b/src/core/components/documentParser/documentParser.test.tsx
@@ -39,4 +39,8 @@ describe('<DocumentParser /> component', () => {
         const rootElement = screen.getByTestId('doc-parser');
         expect(rootElement).toHaveClass('test-class');
     });
+
+    it('does not fail when immediatelyRender is set to false', () => {
+        expect(() => render(createTestComponent({ immediatelyRender: false }))).not.toThrow();
+    });
 });

--- a/src/core/components/documentParser/documentParser.tsx
+++ b/src/core/components/documentParser/documentParser.tsx
@@ -1,5 +1,5 @@
 import { Image } from '@tiptap/extension-image';
-import { EditorContent, useEditor } from '@tiptap/react';
+import { EditorContent, useEditor, type Editor } from '@tiptap/react';
 import { StarterKit } from '@tiptap/starter-kit';
 import classNames from 'classnames';
 import { useEffect, type ComponentPropsWithoutRef } from 'react';
@@ -33,10 +33,15 @@ export const DocumentParser: React.FC<IDocumentParserProps> = (props) => {
     };
 
     const extensions = [StarterKit.configure({ link: { openOnClick: false } }), Image, Markdown];
-    const parser = useEditor({ editable: false, immediatelyRender, extensions, content: sanitizeDocument(document) });
+    const parser = useEditor({
+        editable: false,
+        immediatelyRender,
+        extensions,
+        content: sanitizeDocument(document),
+    }) as Editor | null;
 
     useEffect(() => {
-        parser.commands.setContent(sanitizeDocument(document));
+        parser?.commands.setContent(sanitizeDocument(document));
     }, [document, parser]);
 
     return (

--- a/src/core/components/forms/textAreaRichText/textAreaRichText.test.tsx
+++ b/src/core/components/forms/textAreaRichText/textAreaRichText.test.tsx
@@ -112,4 +112,8 @@ describe('<TextAreaRichText /> component', () => {
         await user.keyboard('{Escape}');
         expect(document.body.style.overflow).toEqual('auto');
     });
+
+    it('does not fail when immediatelyRender is set to false', () => {
+        expect(() => render(createTestComponent({ immediatelyRender: false }))).not.toThrow();
+    });
 });

--- a/src/core/components/forms/textAreaRichText/textAreaRichText.tsx
+++ b/src/core/components/forms/textAreaRichText/textAreaRichText.tsx
@@ -1,5 +1,5 @@
 import { Placeholder } from '@tiptap/extensions';
-import { EditorContent, useEditor } from '@tiptap/react';
+import { type Editor, EditorContent, useEditor } from '@tiptap/react';
 import { StarterKit } from '@tiptap/starter-kit';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
@@ -107,7 +107,7 @@ export const TextAreaRichText: React.FC<ITextAreaRichTextProps> = (props) => {
 
             onChange?.(value);
         },
-    });
+    }) as Editor | null;
 
     const toggleExpanded = () => setIsExpanded((current) => !current);
 
@@ -122,9 +122,7 @@ export const TextAreaRichText: React.FC<ITextAreaRichTextProps> = (props) => {
     }, [isExpanded]);
 
     // Update editable setting on Tiptap editor on disabled property change
-    useEffect(() => {
-        editor.setEditable(!disabled);
-    }, [editor, disabled]);
+    useEffect(() => editor?.setEditable(!disabled), [editor, disabled]);
 
     // Add keydown listener to reset expanded state on ESC key down
     useEffect(() => {


### PR DESCRIPTION
## Description

- Fix TextAreaRichText and DocumentParser components after tiptap migration

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] (For User Stories only) Double-checked that all Acceptance Criteria are satisified
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project
