### PR TITLE
fix(APP-1011): Repair the published CSS bundle and the number mask

### DIFF
--- a/.changeset/fix-build-css-and-number-mask.md
+++ b/.changeset/fix-build-css-and-number-mask.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": patch
+---
+
+Fix the precompiled `build.css` bundle, which was minified by a nesting-unaware pass that merged the selector lists of Tailwind's nested variant rules: ~140 `2xl:*` utilities removed the border of their last child and ~54 `md:*` utilities gave every child a right border, so consumers of the published CSS saw stray vertical bars on components such as `AlertCard` and `Accordion`. The bundle is now minified by Tailwind's own optimizer and is byte-identical to a source compile, and `pnpm check:css` guards it in CI. Also render `InputNumber` and `InputNumberMax` `prefix`/`suffix` values literally instead of parsing them as imask pattern definitions (`suffix="days"` rendered as `d_ys`), and clamp out-of-range values to `min`/`max` instead of dropping the offending character (`50` rendered as `5` when `max` was `20`). `min` and `max` are hard input boundaries, so an out-of-range error state must be rendered through the `alert` property.

--- a/.github/workflows/library-test.yml
+++ b/.github/workflows/library-test.yml
@@ -29,6 +29,8 @@ jobs:
           fetch-depth: 0
       - name: Build library
         run: pnpm build
+      - name: Check published CSS bundle
+        run: pnpm check:css
       - name: Build storybook
         run: pnpm build:storybook
       - name: Run tests with coverage

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "test:coverage": "jest --coverage",
         "lint": "biome check --write --no-errors-on-unmatched --files-ignore-unknown=true",
         "lint:check": "biome check --no-errors-on-unmatched --files-ignore-unknown=true",
-        "type-check": "tsc --noemit"
+        "type-check": "tsc --noemit",
+        "check:css": "node scripts/check-build-css.mjs"
     },
     "repository": {
         "type": "git",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,6 +5,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import svgr from '@svgr/rollup';
+import tailwindcss from '@tailwindcss/postcss';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
 import { visualizer } from 'rollup-plugin-visualizer';
@@ -60,6 +61,8 @@ export default [
     {
         input: 'index.css',
         output: { file: 'build.css' },
-        plugins: [postcss({ plugins: [], extract: true, minimize: true })],
+        // Minify through Tailwind's own optimizer (Lightning CSS): the postcss plugin's cssnano pass predates CSS
+        // nesting and merges the selector lists of nested rules, which leaks child styles across unrelated utilities.
+        plugins: [postcss({ config: false, plugins: [tailwindcss({ optimize: { minify: true } })], extract: true })],
     },
 ];

--- a/scripts/check-build-css.mjs
+++ b/scripts/check-build-css.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Smoke check for the precompiled CSS bundle that consumers import (`build.css`).
+//
+// The bundle is minified, and a nesting-unaware minifier merges the selector lists of rules whose bodies are nested
+// blocks. Tailwind v4 emits every variant utility as a nested block, so such a merge gives dozens of unrelated
+// utilities a child-targeting rule they never declared: `@aragon/gov-ui-kit@2.8.1` shipped ~140 `2xl:*` utilities that
+// removed the border of their last child, and ~54 `md:*` utilities that gave every child a right border. The app and
+// Storybook compile the kit from source, so only consumers of this file are affected — which is why nothing caught it.
+//
+// Usage: node scripts/check-build-css.mjs [path-to-build.css]
+
+import { readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postcss from 'postcss';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const cssPath = resolve(repoRoot, process.argv[2] ?? 'build.css');
+const cssName = relative(repoRoot, cssPath);
+
+// Anything below this means the build produced a stub instead of the real bundle (the file was ~100 KB in v2.9.0).
+const minimumBytes = 50_000;
+
+let css;
+try {
+    css = readFileSync(cssPath, 'utf8');
+} catch (error) {
+    if (error.code === 'ENOENT') {
+        console.error(`check-build-css: ${cssName} not found — run \`pnpm build\` first`);
+        process.exit(1);
+    }
+    throw error;
+}
+
+const problems = [];
+
+if (css.length < minimumBytes) {
+    problems.push(`${cssName} is ${css.length} bytes, expected at least ${minimumBytes}`);
+}
+
+const root = postcss.parse(css, { from: cssPath });
+
+// Two shapes of the same corruption, because a minifier may keep the nesting or flatten it away:
+//   nested    `.md\:flex, .md\:h-4 { @media … { :is(& > *) { border-right-width: 1px } } }`
+//   flattened `.md\:flex > *, .md\:h-4 > * { border-right-width: 1px }`
+// Legitimate output keeps child-targeting rules on the one utility that declares them: v2.9.0 has 37 with a single
+// selector and 1 with two (`.space-y-*` reverse pairs), so a list any longer than that is a merge.
+const maxChildTargetingSelectors = 3;
+
+root.walkRules((rule) => {
+    if (rule.selectors.length < 2) {
+        return;
+    }
+
+    const line = rule.source?.start?.line ?? '?';
+    const preview = rule.selectors.slice(0, 3).join(', ');
+
+    const leaked = [];
+    rule.walkRules((nested) => {
+        if (/&\s*>/.test(nested.selector)) {
+            leaked.push(nested.selector);
+        }
+    });
+
+    if (leaked.length) {
+        problems.push(
+            `${rule.selectors.length} selectors share a nested child-targeting rule (${leaked.join(' / ')}) — ` +
+                `starting at "${preview}" on line ${line}`,
+        );
+    } else if (rule.selectors.length > maxChildTargetingSelectors && rule.selectors.some((s) => s.includes('>'))) {
+        problems.push(
+            `${rule.selectors.length} child-targeting selectors share one declaration block — ` +
+                `starting at "${preview}" on line ${line}`,
+        );
+    }
+});
+
+if (problems.length) {
+    console.error(`check-build-css: ${problems.length} problem(s) in ${cssName}`);
+    for (const problem of problems) {
+        console.error(`  - ${problem}`);
+    }
+    console.error(
+        '  The CSS minifier merged selector lists across nested rules. Check the minifier in rollup.config.mjs.',
+    );
+    process.exit(1);
+}
+
+console.log(`check-build-css: ok (${cssName}, ${css.length} bytes, ${root.nodes.length} top-level nodes)`);

--- a/src/core/components/forms/hooks/useNumberMask.test.ts
+++ b/src/core/components/forms/hooks/useNumberMask.test.ts
@@ -31,7 +31,7 @@ describe('useNumberMask hook', () => {
     it('sets the mask to be a number mask with decimals', () => {
         renderHook(() => useNumberMask({}));
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const expectedNumberBlock = { num: { mask: Number, scale: expect.any(Number) } };
+        const expectedNumberBlock = { num: expect.objectContaining({ mask: Number, scale: expect.any(Number) }) };
         expect(maskMock).toHaveBeenCalledWith(
             expect.objectContaining({ mask: 'num', blocks: expectedNumberBlock }),
             expect.anything(),
@@ -64,20 +64,27 @@ describe('useNumberMask hook', () => {
         );
     });
 
-    it('sets the defined prefix and suffix on the mask', () => {
-        const prefix = '>';
-        const suffix = 'ETH';
-        renderHook(() => useNumberMask({ prefix, suffix }));
+    it('escapes the defined prefix and suffix on the mask so that they render literally', () => {
+        renderHook(() => useNumberMask({ prefix: '>', suffix: 'ETH' }));
         expect(maskMock).toHaveBeenCalledWith(
-            expect.objectContaining({ mask: `${prefix} num ${suffix}` }),
+            expect.objectContaining({ mask: '\\> num \\E\\T\\H' }),
             expect.anything(),
         );
     });
 
     it('correctly set the mask when only suffix is set', () => {
-        const suffix = '%';
-        renderHook(() => useNumberMask({ suffix }));
-        expect(maskMock).toHaveBeenCalledWith(expect.objectContaining({ mask: `num ${suffix}` }), expect.anything());
+        renderHook(() => useNumberMask({ suffix: '%' }));
+        expect(maskMock).toHaveBeenCalledWith(expect.objectContaining({ mask: 'num \\%' }), expect.anything());
+    });
+
+    it('clamps out-of-range values instead of rejecting the out-of-range character', () => {
+        renderHook(() => useNumberMask({ max: 100 }));
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const expectedNumberBlock = { num: expect.objectContaining({ autofix: true }) };
+        expect(maskMock).toHaveBeenCalledWith(
+            expect.objectContaining({ blocks: expectedNumberBlock }),
+            expect.anything(),
+        );
     });
 
     it('updates the unmasked value on value property change for controlled inputs', () => {

--- a/src/core/components/forms/hooks/useNumberMask.ts
+++ b/src/core/components/forms/hooks/useNumberMask.ts
@@ -40,7 +40,12 @@ export const useNumberMask = (props: IUseNumberMaskProps): IUseNumberMaskResult 
 
     const { thousandsSeparator, radix } = getNumberSeparators();
 
-    const numberMask = `${prefix ?? ''} num ${suffix ?? ''}`.trim();
+    // imask parses the mask as a pattern: an unescaped character is matched against a mask definition (`0`, `a`, `*`)
+    // or a block name (`num`), so an unescaped suffix such as "days" renders as "d_ys". Escape every character to
+    // keep the prefix and suffix literal.
+    const maskPrefix = prefix?.replace(/./gsu, '\\$&') ?? '';
+    const maskSuffix = suffix?.replace(/./gsu, '\\$&') ?? '';
+    const numberMask = `${maskPrefix} num ${maskSuffix}`.trim();
     const maskMax = max == null ? undefined : Number(max);
     const maskMin = min == null ? undefined : Number(min);
 
@@ -54,7 +59,17 @@ export const useNumberMask = (props: IUseNumberMaskProps): IUseNumberMaskResult 
             mask: numberMask,
             eager: true, // Displays eventual suffix on user input
             blocks: {
-                num: { mask: Number, radix, thousandsSeparator, scale: defaultScale, max: maskMax, min: maskMin },
+                num: {
+                    mask: Number,
+                    radix,
+                    thousandsSeparator,
+                    scale: defaultScale,
+                    max: maskMax,
+                    min: maskMin,
+                    // Clamp out-of-range values to the boundary. Without it imask rejects the offending character
+                    // instead, which truncates the value (e.g. 50 renders as 5 when max is 20).
+                    autofix: true,
+                },
             },
         },
         { onAccept: handleMaskAccept },

--- a/src/core/components/forms/inputNumber/inputNumber.stories.tsx
+++ b/src/core/components/forms/inputNumber/inputNumber.stories.tsx
@@ -36,7 +36,8 @@ export const Controlled: Story = {
 };
 
 /**
- * Usage example with min and max values.
+ * Usage example with min and max values. Both are hard boundaries of the input: out-of-range values are clamped to
+ * them, so an out-of-range error state must be rendered through the `alert` property instead.
  */
 export const MinMax: Story = {
     args: {

--- a/src/core/components/forms/inputNumber/inputNumber.test.tsx
+++ b/src/core/components/forms/inputNumber/inputNumber.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { IconType } from '../../icon';
 import * as InputHooks from '../hooks';
 import { type IInputNumberProps, InputNumber } from './inputNumber';
+
+const { useNumberMask: actualUseNumberMask } = jest.requireActual<typeof InputHooks>('../hooks');
 
 describe('<InputNumber /> component', () => {
     const useNumberMaskMock = jest.spyOn(InputHooks, 'useNumberMask');
@@ -22,6 +24,29 @@ describe('<InputNumber /> component', () => {
 
         return <InputNumber {...completeProps} />;
     };
+
+    // These cases run the real imask instance because a mocked mask cannot show what the pattern renders.
+    describe('number mask', () => {
+        beforeEach(() => {
+            useNumberMaskMock.mockImplementation(actualUseNumberMask);
+        });
+
+        it.each([
+            { props: { suffix: 'days' }, expected: '5 days' },
+            { props: { prefix: '~' }, expected: '~ 5' },
+            { props: { prefix: '>', suffix: 'ETH' }, expected: '> 5 ETH' },
+        ])('renders $props as literal text instead of a mask pattern', async ({ props, expected }) => {
+            render(createTestComponent({ ...props, value: '5' }));
+            await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue(expected));
+        });
+
+        it('clamps a value above max to max instead of truncating it', async () => {
+            const onChange = jest.fn();
+            render(createTestComponent({ max: 20, value: '50', onChange }));
+            await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue('20'));
+            expect(onChange).toHaveBeenCalledWith('20');
+        });
+    });
 
     const testChangeValueLogic = async (values?: {
         props?: Partial<IInputNumberProps>;

--- a/src/core/components/forms/inputNumber/inputNumber.tsx
+++ b/src/core/components/forms/inputNumber/inputNumber.tsx
@@ -10,12 +10,14 @@ import { type IInputComponentProps, InputContainer } from '../inputContainer';
 export interface IInputNumberProps
     extends Omit<IInputComponentProps, 'onChange' | 'step' | 'min' | 'max' | 'maxLength'> {
     /**
-     * The minimum value that the number input accepts.
+     * The minimum value that the number input accepts. Values below it are clamped to it, so use the `alert` property
+     * instead of `min` to display an out-of-range value in an error state.
      * @default Number.MIN_SAFE_INTEGER
      */
     min?: number;
     /**
-     * The maximum value that the number input accepts.
+     * The maximum value that the number input accepts. Values above it are clamped to it, so use the `alert` property
+     * instead of `max` to display an out-of-range value in an error state.
      * @default Number.MAX_SAFE_INTEGER
      */
     max?: number;

--- a/src/core/components/forms/inputNumberMax/inputNumberMax.tsx
+++ b/src/core/components/forms/inputNumberMax/inputNumberMax.tsx
@@ -6,7 +6,8 @@ import { type IInputComponentProps, InputContainer } from '../inputContainer';
 
 export interface IInputNumberMaxProps extends Omit<IInputComponentProps, 'maxLength' | 'onChange'> {
     /**
-     * Maximum number set on max button click.
+     * Maximum number set on max button click. It is also the ceiling the input accepts: values above it are clamped to
+     * it, so use the `alert` property to display an out-of-range value in an error state.
      */
     max: number;
     /**


### PR DESCRIPTION
## Description

Fixes the two `@aragon/gov-ui-kit` issues the [app design-sync run](https://github.com/aragon/app/pull/1243) reported upstream, and adds a CI guard for the one that only affects consumers of the published package. Implements the kit half of APP-1011; the `aragon/app` bump + re-sync is the follow-up half.

### 1. `build.css` was corrupted by its minifier

`rollup-plugin-postcss`'s `minimize: true` runs cssnano 5, which predates CSS nesting. Tailwind v4 emits every variant utility as a nested block, and the merge pass collapsed the selector lists of unrelated utilities onto one nested body. On `main` (v2.9.0) that produced 4 corrupted rules:

| selectors | inherited child rule |
|---|---|
| 140 `2xl:*` | `& > :last-child { border-style: none }` |
| 128 `md:*`/`sm:*` | `:where(& > :not(:last-child)) { margin-block: 0 }` |
| 54 `md:*` | `:is(& > *) { border-right-width: 1px }` |
| 7 `md:*` | `:where(& > :not(:last-child)) { margin-inline… }` |

That is the stray vertical bar on `AlertCard`/`Accordion` in the design-sync previews. Invisible in the app and Storybook because both compile the kit from source — only consumers of the precompiled file are affected.

Fix: minify with Tailwind's own optimizer (Lightning CSS, nesting-aware) instead of cssnano. The result is **byte-identical to a direct source compile** (`cmp build.css` against `@tailwindcss/postcss` output: 118,809 bytes both) and has zero corrupted rules. It is 15 KB larger than the corrupted bundle, which is the cost of the rules that were being wrongly merged away.

`scripts/check-build-css.mjs` + `pnpm check:css` runs in CI right after `pnpm build`, following the `check-agents-md.mjs` shape from #739 — plain Node, no new framework. It fails on both shapes of the corruption (nesting kept, nesting flattened) and on a stub-sized bundle. Verified it reports all 4 rules on the pre-fix bundle and exits 0 on the fixed one.

### 2. `prefix`/`suffix` were parsed as imask pattern, and `max` truncated

`useNumberMask` interpolated `prefix`/`suffix` straight into the imask pattern, where `a`, `0` and `*` are mask definitions and `num` is a block name — so `<InputNumber suffix="days" />` rendered `d_ys`. Every character is now escaped, so prefixes and suffixes are literal.

The `max` behaviour was worse than the ticket described: imask rejects the character that would exceed the bound rather than clamping, so `max={20}` with `value="50"` rendered **`5`**, and `onChange` emitted `"5"`. Typing `99` left `9`. Decision: `min`/`max` are hard input boundaries and now clamp (`autofix`), so `50` renders `20` and `onChange` emits `"20"` — the consumer's state converges instead of silently losing a digit. An out-of-range error state is expressed through the input's `alert` property, not by passing `max`; documented on both components' props and the `MinMax` story.

Tests run the real imask instance for these cases — the existing suite mocked `useNumberMask`, which is why a pattern bug could not surface. Confirmed the new cases fail on the pre-fix hook.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Behaviour change worth calling out: over-max input clamps instead of truncating. Both are input-ceiling behaviours, no API change.

## Developer Checklist:

- [x] Manually smoke tested the functionality locally — `pnpm build` then `pnpm check:css` (fails with 4 rules before the fix, ok after); probed the mask in jsdom for controlled/typed/decimal values
- [x] Confirmed there are no new warnings or errors in the browser console — no console output changes; `pnpm build` clean
- [x] Made the corresponding changes to the documentation — `min`/`max` props on `InputNumber` and `InputNumberMax`, `MinMax` story, changeset
- [x] Added tests that prove my fix is effective or that my feature works — literal prefix/suffix and clamping cases on `InputNumber` (real mask), pattern and `autofix` cases on `useNumberMask`
- [x] Confirmed there are no new warnings on automated tests — 1125 tests pass
- [x] Selected the correct base branch (`main`)
- [x] Commented the code in hard-to-understand areas — the escape and clamp reasons, and the full failure mode at the top of `check-build-css.mjs`
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub's UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

## Review Checklist:

- [ ] Tested locally that all Acceptance Criteria or Expected Outcomes are satisfied
- [ ] Confirmed that changes follow the code style guidelines of this project

## Notes

- Touches `package.json` scripts and `library-test.yml` alongside #739 (APP-723), which adds `check:agents` in the same two places — trivial conflict, whichever lands second rebases.
- Follow-up (APP-1011, app side, blocked on a kit release): bump `@aragon/gov-ui-kit` in `aragon/app`, drop the `InputNumber`/`InputNumberMax` preview workarounds and the `build.css` avoidance note, re-run the design-sync flow from `.design-sync/NOTES.md`, and accept the `AlertCard`/`Accordion` render-hash invalidations that come from this CSS fix.
