### PR TITLE
ci: exclude version-locked families from npm minor-and-patch group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
         update-types:
           - "patch"
           - "minor"
+        # Version-locked / high-blast-radius families: exclude from the auto-bundle
+        # so they update via dedicated PRs. @tiptap/* must move as one family
+        # (a split dedupes to two @tiptap/core copies and fails type-check);
+        # sanitize-html 2.17.6 is an ESM-only htmlparser2 rewrite that breaks jest;
+        # react-hook-form 7.84 changed runtime behavior and broke a test.
+        exclude-patterns:
+          - "@tiptap/*"
+          - "tiptap-markdown"
+          - "sanitize-html"
+          - "react-hook-form"
       storybook:
         patterns:
           - "@storybook*"


### PR DESCRIPTION
Keep these families out of the weekly npm minor-and-patch group so they update on their own PRs.

@tiptap/* and tiptap-markdown must move as one family. In dependabot's group, starter-kit and the extensions went to 3.29.2 while react, core, and pm stayed on 3.26.1, which left two @tiptap/core copies and failed type-check.

sanitize-html: 2.17.6 swaps htmlparser2 to an ESM-only build that breaks jest. Holding at 2.17.5 for now.

react-hook-form: 7.84 changed runtime behavior (now forwards resetDefaultValues) and broke a test. Bump it deliberately, with the test update, when we take it.

Without this, every weekly group run reproduces a broken bundle.