### PR TITLE
feat(APP-1089): Resolve AddressOutput controls from the container

### DIFF
--- a/.changeset/interactive-ancestor-context.md
+++ b/.changeset/interactive-ancestor-context.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": minor
+---
+
+`AddressOutput` now takes its `copy` and `reveal` defaults from its container: both stay `true` standalone and become `false` inside an interactive element such as a link, an interactive `DataList.Item` row, or the `Wallet` button, where a nested control is invalid markup and competes with the container for the click. Pass either prop explicitly to override, as `ProposalDataListItem` and `SmartContractFunctionDataListItem` do for their isolated links. Containers built outside the kit can mark themselves with the newly exported `InteractiveAncestorProvider`.

--- a/src/core/components/dataList/dataListItem/dataListItem.tsx
+++ b/src/core/components/dataList/dataListItem/dataListItem.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import type { AnchorHTMLAttributes, HTMLAttributes } from 'react';
+import { InteractiveAncestorProvider } from '../../interactiveAncestor';
 import { LinkBase } from '../../link';
 
 export type DataListItemVariant = 'primary' | 'select';
@@ -64,15 +65,17 @@ export const DataListItem: React.FC<IDataListItemProps> = (props) => {
         };
 
         return (
-            // biome-ignore lint/a11y/useSemanticElements: interactive div with keyboard support matching existing API
-            <div
-                className={actionItemClasses}
-                onClick={handleClick}
-                onKeyDown={handleKeyDown}
-                role="button"
-                tabIndex={0}
-                {...divProps}
-            />
+            <InteractiveAncestorProvider value={true}>
+                {/* biome-ignore lint/a11y/useSemanticElements: interactive div with keyboard support matching existing API */}
+                <div
+                    className={actionItemClasses}
+                    onClick={handleClick}
+                    onKeyDown={handleKeyDown}
+                    role="button"
+                    tabIndex={0}
+                    {...divProps}
+                />
+            </InteractiveAncestorProvider>
         );
     }
 

--- a/src/core/components/index.ts
+++ b/src/core/components/index.ts
@@ -16,6 +16,7 @@ export * from './gukCoreProvider';
 export * from './heading';
 export * from './icon';
 export * from './illustrations';
+export * from './interactiveAncestor';
 export * from './link';
 export * from './progress';
 export * from './rerender';

--- a/src/core/components/interactiveAncestor/index.ts
+++ b/src/core/components/interactiveAncestor/index.ts
@@ -1,0 +1,1 @@
+export { InteractiveAncestorProvider, useInteractiveAncestor } from './interactiveAncestorContext';

--- a/src/core/components/interactiveAncestor/interactiveAncestorContext.ts
+++ b/src/core/components/interactiveAncestor/interactiveAncestorContext.ts
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+const interactiveAncestorContext = createContext(false);
+
+/**
+ * Marks its subtree as living inside an interactive element (a link, a button, or a row with an onClick handler).
+ * Components that render their own interactive affordances read this to avoid nesting a control inside a control,
+ * which is invalid markup, adds a phantom tab stop, and competes with the container for the click.
+ */
+export const InteractiveAncestorProvider = interactiveAncestorContext.Provider;
+
+export const useInteractiveAncestor = (): boolean => useContext(interactiveAncestorContext);

--- a/src/core/components/link/linkBase/linkBase.tsx
+++ b/src/core/components/link/linkBase/linkBase.tsx
@@ -1,12 +1,17 @@
 import { type ComponentPropsWithoutRef, forwardRef } from 'react';
 import { useGukCoreContext } from '../../gukCoreProvider';
+import { InteractiveAncestorProvider } from '../../interactiveAncestor';
 
 export interface ILinkBaseProps extends ComponentPropsWithoutRef<'a'> {}
 
 export const LinkBase = forwardRef<HTMLAnchorElement, ILinkBaseProps>((props, ref) => {
     const { Link } = useGukCoreContext();
 
-    return <Link ref={ref} {...props} />;
+    return (
+        <InteractiveAncestorProvider value={true}>
+            <Link ref={ref} {...props} />
+        </InteractiveAncestorProvider>
+    );
 });
 
 LinkBase.displayName = 'LinkBase';

--- a/src/modules/components/address/addressOutput/addressOutput.test.tsx
+++ b/src/modules/components/address/addressOutput/addressOutput.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { clipboardUtils } from '../../../../core';
+import { clipboardUtils, DataList } from '../../../../core';
 import { AddressOutput, type IAddressOutputProps } from './addressOutput';
 
 describe('<AddressOutput /> component', () => {
@@ -113,6 +113,28 @@ describe('<AddressOutput /> component', () => {
         render(createTestComponent({ copy: false, reveal: false }));
         expect(screen.queryByRole('button')).not.toBeInTheDocument();
         expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('renders no controls inside a link container', () => {
+        render(<DataList.Item href="https://etherscan.io">{createTestComponent()}</DataList.Item>);
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+        expect(screen.getByRole('link')).toHaveTextContent('0xd8da…6045');
+    });
+
+    it('renders no controls inside a clickable container', () => {
+        render(<DataList.Item onClick={jest.fn()}>{createTestComponent()}</DataList.Item>);
+        expect(screen.queryByRole('button', { name: 'Copy' })).not.toBeInTheDocument();
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+    });
+
+    it('keeps the controls inside a container when the flags are set explicitly', () => {
+        render(
+            <DataList.Item href="https://etherscan.io">
+                {createTestComponent({ copy: true, reveal: true })}
+            </DataList.Item>,
+        );
+        expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: '0xd8da…6045' })).toBeInTheDocument();
     });
 
     it('displays the value as is when it is not a valid address', async () => {

--- a/src/modules/components/address/addressOutput/addressOutput.tsx
+++ b/src/modules/components/address/addressOutput/addressOutput.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { type PointerEvent as ReactPointerEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { Clipboard, Link, Tooltip } from '../../../../core';
+import { Clipboard, Link, Tooltip, useInteractiveAncestor } from '../../../../core';
 import { addressUtils } from '../../../utils';
 
 export interface IAddressOutputProps {
@@ -30,13 +30,14 @@ export interface IAddressOutputProps {
      */
     isExternal?: boolean;
     /**
-     * Renders an inline copy control that copies the full checksummed address.
-     * @default true
+     * Renders an inline copy control that copies the full checksummed address. Defaults to `true`, or to `false`
+     * inside an interactive container such as a link or a data list row, where a nested control would be invalid
+     * markup and compete for the click. Set explicitly to override.
      */
     copy?: boolean;
     /**
-     * Reveals the full checksummed address on hover, keyboard focus and tap.
-     * @default true
+     * Reveals the full checksummed address on hover, keyboard focus and tap. Defaults to `true`, or to `false` inside
+     * an interactive container, for the same reason as `copy`. Set explicitly to override.
      */
     reveal?: boolean;
     /**
@@ -46,16 +47,13 @@ export interface IAddressOutputProps {
 }
 
 export const AddressOutput: React.FC<IAddressOutputProps> = (props) => {
-    const {
-        address,
-        label,
-        showCompleteAddress = false,
-        href,
-        isExternal = true,
-        copy = true,
-        reveal = true,
-        className,
-    } = props;
+    const { address, label, showCompleteAddress = false, href, isExternal = true, copy, reveal, className } = props;
+
+    const hasInteractiveAncestor = useInteractiveAncestor();
+
+    // The container knows whether a nested control is legal here; the props stay as an explicit override.
+    const showCopy = copy ?? !hasInteractiveAncestor;
+    const showReveal = reveal ?? !hasInteractiveAncestor;
 
     const isLink = href != null && href.length > 0;
 
@@ -151,7 +149,7 @@ export const AddressOutput: React.FC<IAddressOutputProps> = (props) => {
 
     let output = labelElement;
 
-    if (reveal) {
+    if (showReveal) {
         output = (
             <Tooltip content={checksumAddress} onOpenChange={handleOpenChange} open={isOpen} triggerAsChild={true}>
                 {isLink ? (
@@ -173,7 +171,7 @@ export const AddressOutput: React.FC<IAddressOutputProps> = (props) => {
     }
 
     // The copy control matches the label: primary circle on a link, neutral circle on plain text.
-    if (copy) {
+    if (showCopy) {
         return (
             <Clipboard copyValue={checksumAddress} size="sm" variant={isLink ? 'avatar' : 'avatar-neutral'}>
                 {output}

--- a/src/modules/components/asset/assetTransfer/assetTransferAddress/assetTransferAddress.tsx
+++ b/src/modules/components/asset/assetTransfer/assetTransferAddress/assetTransferAddress.tsx
@@ -72,7 +72,6 @@ export const AssetTransferAddress: React.FC<IAssetTransferAddressProps> = (props
                         address={participant.address}
                         className="truncate font-normal text-neutral-800 text-sm leading-tight md:text-base"
                         label={resolvedUserHandle}
-                        reveal={true}
                     />
                     <Icon
                         className="float-right text-neutral-300 group-hover:text-primary-300 group-active:text-primary-400"

--- a/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.tsx
+++ b/src/modules/components/dao/daoDataListItem/daoDataListItemStructure/daoDataListItemStructure.tsx
@@ -41,9 +41,6 @@ export const DaoDataListItemStructure: React.FC<IDaoDataListItemStructureProps> 
     const truncatedAddress = addressUtils.truncateAddress(address);
     const addressLine = ens ?? truncatedAddress;
 
-    // The item renders as a link or a button when interactive, so the reveal must not add a nested interactive trigger.
-    const isInteractiveItem = ('href' in otherProps && otherProps.href != null) || otherProps.onClick != null;
-
     return (
         <DataList.Item className="grid gap-y-3 py-4 md:gap-y-4 md:py-6" {...otherProps}>
             <div className="flex w-full justify-between gap-2">
@@ -56,13 +53,7 @@ export const DaoDataListItemStructure: React.FC<IDaoDataListItemStructureProps> 
                             {address == null ? (
                                 addressLine
                             ) : (
-                                <AddressOutput
-                                    address={address}
-                                    className="truncate"
-                                    copy={!isInteractiveItem}
-                                    label={addressLine}
-                                    reveal={true}
-                                />
+                                <AddressOutput address={address} className="truncate" label={addressLine} />
                             )}
                         </Heading>
                     )}

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.tsx
@@ -70,9 +70,6 @@ export const MemberDataListItemStructure: React.FC<IMemberDataListItemProps> = (
 
     const resolvedUserHandle = ensName != null && ensName.length > 0 ? ensName : addressUtils.truncateAddress(address);
 
-    // The item renders as a link or a button when interactive, so the reveal must not add a nested interactive trigger.
-    const isInteractiveItem = ('href' in otherProps && otherProps.href != null) || otherProps.onClick != null;
-
     const showDelegationOrTokenInformation = delegationCount != null || tokenAmount != null;
 
     const formattedDelegationCount = formatterUtils.formatNumber(delegationCount, {
@@ -102,13 +99,7 @@ export const MemberDataListItemStructure: React.FC<IMemberDataListItemProps> = (
                 {isCurrentUser && <Tag label={copy.memberDataListItemStructure.you} variant="neutral" />}
             </div>
             <Heading as="h2" className="inline-block w-full truncate" size="h3">
-                <AddressOutput
-                    address={address}
-                    className="truncate"
-                    copy={!isInteractiveItem}
-                    label={resolvedUserHandle}
-                    reveal={true}
-                />
+                <AddressOutput address={address} className="truncate" label={resolvedUserHandle} />
             </Heading>
             {showDelegationOrTokenInformation && (
                 <div className="flex flex-col gap-y-2">

--- a/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.tsx
+++ b/src/modules/components/proposal/proposalDataListItem/proposalDataListItemStructure/proposalDataListItemStructure.tsx
@@ -91,10 +91,12 @@ export const ProposalDataListItemStructure: React.FC<IProposalDataListItemStruct
                         parsedPublisher.map(({ address, label, link }, index) => (
                             <span className="truncate" key={`${address}-${index.toString()}`}>
                                 <object className="flex shrink" type="unknown">
-                                    {/* The object element already isolates the item link, so the reveal trigger can stay interactive. */}
+                                    {/* The object element isolates the item link, so the controls stay interactive
+                                        here and opt out of the container's suppression explicitly. */}
                                     <AddressOutput
                                         address={address}
                                         className="truncate"
+                                        copy={true}
                                         href={link}
                                         isExternal={false}
                                         label={label}

--- a/src/modules/components/smartContract/smartContractFunctionDataListItem/smartContractFunctionDataListItemStructure/smartContractFunctionDataListItemStructure.tsx
+++ b/src/modules/components/smartContract/smartContractFunctionDataListItem/smartContractFunctionDataListItemStructure/smartContractFunctionDataListItemStructure.tsx
@@ -87,7 +87,7 @@ export const SmartContractFunctionDataListItemStructure: React.FC<ISmartContract
                     <p className="text-neutral-500">{contractLabel}</p>
                     {/* Using solution from https://kizu.dev/nested-links/ to nest anchor tags */}
                     <object type="unknown">
-                        <AddressOutput address={contractAddress} href={blockExplorerHref} reveal={true} />
+                        <AddressOutput address={contractAddress} copy={true} href={blockExplorerHref} reveal={true} />
                     </object>
                 </LinkBase>
             </div>

--- a/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.tsx
+++ b/src/modules/components/transaction/transactionDataListItem/transactionDataListItemStructure/transactionDataListItemStructure.tsx
@@ -107,12 +107,7 @@ export const TransactionDataListItemStructure: React.FC<ITransactionDataListItem
                     {isExecution && processedLabel != null && (
                         <span className="text-neutral-500">
                             {' '}
-                            {addressLabel == null ? (
-                                processedLabel
-                            ) : (
-                                // The item always renders as a link, so a tap must keep opening the block explorer.
-                                <AddressOutput address={addressLabel} reveal={true} />
-                            )}
+                            {addressLabel == null ? processedLabel : <AddressOutput address={addressLabel} />}
                         </span>
                     )}
                 </span>

--- a/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.tsx
+++ b/src/modules/components/vote/voteDataListItem/voteDataListItemStructure/voteDataListItemStructure.tsx
@@ -67,9 +67,6 @@ export const VoteDataListItemStructure: React.FC<IVoteDataListItemStructureProps
     const resolvedUserHandle =
         voter.name != null && voter.name.length > 0 ? voter.name : addressUtils.truncateAddress(voter.address);
 
-    // The item renders as a link or a button when interactive, so the reveal must not add a nested interactive trigger.
-    const isInteractiveItem = ('href' in otherProps && otherProps.href != null) || otherProps.onClick != null;
-
     const formattedTokenNumber = formatterUtils.formatNumber(votingPower, { format: NumberFormat.TOKEN_AMOUNT_SHORT });
     const formattedTokenVote =
         formattedTokenNumber != null && tokenSymbol != null ? `${formattedTokenNumber} ${tokenSymbol}` : undefined;
@@ -93,13 +90,7 @@ export const VoteDataListItemStructure: React.FC<IVoteDataListItemStructureProps
             />
             <div className={centerInfoClassNames}>
                 <span className="flex items-center gap-x-1 text-base text-neutral-800 md:gap-x-1.5 md:text-lg">
-                    <AddressOutput
-                        address={voter.address}
-                        className="truncate"
-                        copy={!isInteractiveItem}
-                        label={resolvedUserHandle}
-                        reveal={true}
-                    />
+                    <AddressOutput address={voter.address} className="truncate" label={resolvedUserHandle} />
                     {isDelegate && !isCurrentUser && (
                         <Tag label={copy.voteDataListItemStructure.yourDelegate} variant="primary" />
                     )}

--- a/src/modules/components/wallet/wallet.tsx
+++ b/src/modules/components/wallet/wallet.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { mainnet } from 'viem/chains';
 import { useEnsName } from 'wagmi';
-import { StateSkeletonBar } from '../../../core';
+import { InteractiveAncestorProvider, StateSkeletonBar } from '../../../core';
 import type { ICompositeAddress, IWeb3ComponentProps } from '../../types';
 import { addressUtils } from '../../utils';
 import { AddressOutput } from '../address/addressOutput';
@@ -38,28 +38,28 @@ export const Wallet: React.FC<IWalletProps> = (props) => {
     );
 
     return (
-        <button className={buttonClassName} {...otherProps}>
-            {!user && copy.wallet.connect}
-            {user && isEnsLoading && <StateSkeletonBar className="hidden xl:block" size="lg" width={56} />}
-            {/* The handle sits inside the connect button, so a tap must keep triggering that button. */}
-            {user && !isEnsLoading && (
-                <AddressOutput
-                    address={user.address}
-                    className="hidden truncate xl:block"
-                    label={resolvedUserHandle}
-                    reveal={true}
-                />
-            )}
-            {user && (
-                <MemberAvatar
-                    address={user.address}
-                    avatarSrc={user.avatarSrc}
-                    chainId={chainId}
-                    ensName={user.name}
-                    size="lg"
-                    wagmiConfig={wagmiConfig}
-                />
-            )}
-        </button>
+        <InteractiveAncestorProvider value={true}>
+            <button className={buttonClassName} {...otherProps}>
+                {!user && copy.wallet.connect}
+                {user && isEnsLoading && <StateSkeletonBar className="hidden xl:block" size="lg" width={56} />}
+                {user && !isEnsLoading && (
+                    <AddressOutput
+                        address={user.address}
+                        className="hidden truncate xl:block"
+                        label={resolvedUserHandle}
+                    />
+                )}
+                {user && (
+                    <MemberAvatar
+                        address={user.address}
+                        avatarSrc={user.avatarSrc}
+                        chainId={chainId}
+                        ensName={user.name}
+                        size="lg"
+                        wagmiConfig={wagmiConfig}
+                    />
+                )}
+            </button>
+        </InteractiveAncestorProvider>
     );
 };


### PR DESCRIPTION
## Description

Whether a nested interactive control is legal is a fact about the *container*, not the caller. Today every callsite re-derives it — `('href' in otherProps && otherProps.href != null) || otherProps.onClick != null`, copy-pasted into three files, and all three then passed `reveal={true}` anyway. This moves the fact to the two chokepoints that already exist and makes the props an explicit override.

```tsx
// core/components/interactiveAncestor
const interactiveAncestorContext = createContext(false);
export const InteractiveAncestorProvider = interactiveAncestorContext.Provider;
export const useInteractiveAncestor = () => useContext(interactiveAncestorContext);

// addressOutput.tsx
const showCopy = copy ?? !hasInteractiveAncestor;
const showReveal = reveal ?? !hasInteractiveAncestor;
```

`LinkBase` provides it, which covers every anchor in the kit including the `DataList.Item` link branch, `AssetTransferAddress` and `smartContractFunctionDataListItemStructure`. `DataListItem`'s interactive-div branch provides it for `role="button"` rows. `Wallet` provides it around its connect button, which a container cannot restructure its way out of.

Unset means "do the right thing here", so `ProposalDataListItem` and `SmartContractFunctionDataListItem` pass `copy` and `reveal` explicitly to keep their `<object>`-isolated links working — React context flows straight through `<object>`, so the escape hatch has to be stated in props. That override is also what consumers outside the kit get: `InteractiveAncestorProvider` is exported so app-side row containers can mark themselves.

Net effect on the kit is deletion: `isInteractiveItem` and its comment leave member, DAO and vote; the explicit `copy`/`reveal` props leave four more callsites.

Verified in Storybook, live DOM, all four container shapes:

| Story | Controls rendered | Nested in anchor/button |
| -- | -- | -- |
| `AssetTransfer` → `Default` | 2 row anchors only | none |
| `Wallet` → `Address` | 1 button | none |
| `AddressOutput` → `Default` (standalone) | reveal + Copy | none |
| `SmartContractFunctionDataListItem` → `Verified` | link + link + Copy | Copy, unchanged and deliberate |

Semver is minor, not major: standalone consumers resolve to `true` exactly as today, and only the nested-in-interactive case changes, which is the case #APP-1108 and the sibling fix PR call a bug. A consumer who deliberately put copy inside a link row keeps it by passing the prop.

Two things worth a reviewer's attention:

1. I considered a dev-only warning for components that are not converted, and dropped it. It would fire on `Clipboard` inside `Link`, which the kit supports on purpose (`clipboard.stories.tsx` → `InsideLink`). Telling accidental nesting from deliberate needs a per-component policy, and a component with a policy can simply not render the control.
2. The `smartContract` Copy button is still a `<button>` inside an `<a>`. This PR preserves 2.10.0 behaviour exactly; the `<object>` trick is documented for nested *links* and I doubt it launders a nested button. That belongs to #APP-1108 rather than a silent change here.

Related: https://linear.app/aragon/issue/APP-1108 asks whether the row should stop swallowing its contents at all, which would let these controls return legitimately. Depends on the sibling fix PR only for merge order — both touch the same prop lines, so whichever lands second drops the redundant deletions.

Linear: https://linear.app/aragon/issue/APP-1089

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Developer Checklist:

- [x] Manually smoke tested the functionality locally
- [x] Confirmed there are no new warnings or errors in the browser console
- [x] Made the corresponding changes to the documentation
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Confirmed there are no new warnings on automated tests
- [x] Selected the correct base branch
- [x] Commented the code in hard-to-understand areas
- [x] Followed the code style guidelines of this project
- [x] Reviewed that the files changed in GitHub’s UI reflect my intended changes
- [x] Confirmed the pipeline checks are not failing

Three tests in `addressOutput.test.tsx` cover the resolution branches through real `DataList.Item` containers — link, clickable row, and explicit override — so they fail if either provider or the `??` resolution breaks. `pnpm build` and `pnpm css:check` pass with the new public export, confirmed in `dist/types/src/core/components/interactiveAncestor/`.
