### PR TITLE
fix: keep address copy controls inside cards

### DIFF
--- a/.changeset/keep-copy-in-card.md
+++ b/.changeset/keep-copy-in-card.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": patch
+---
+
+Keep address copy controls inside narrow cards.

--- a/src/core/components/clipboard/clipboard.tsx
+++ b/src/core/components/clipboard/clipboard.tsx
@@ -50,7 +50,7 @@ export const Clipboard: React.FC<IClipboardProps> = (props) => {
     };
 
     return (
-        <div className={classNames('flex items-center gap-2', className)}>
+        <div className={classNames('flex min-w-0 items-center gap-2', className)}>
             {children}
             {(variant === 'avatar' || variant === 'avatar-neutral') && (
                 <Tooltip content={tooltipText} triggerAsChild={true}>

--- a/src/core/components/dataList/dataListItem/dataListItem.tsx
+++ b/src/core/components/dataList/dataListItem/dataListItem.tsx
@@ -46,7 +46,7 @@ export const DataListItem: React.FC<IDataListItemProps> = (props) => {
 
     const interactiveContent = (
         <div
-            className="pointer-events-none relative z-10 [&_[role=button]]:pointer-events-auto [&_a]:pointer-events-auto [&_button]:pointer-events-auto"
+            className="pointer-events-none relative z-10 w-full min-w-0 [&_[role=button]]:pointer-events-auto [&_a]:pointer-events-auto [&_button]:pointer-events-auto"
             id={contentId}
         >
             {children}

--- a/src/modules/components/address/addressOutput/addressOutput.tsx
+++ b/src/modules/components/address/addressOutput/addressOutput.tsx
@@ -151,7 +151,7 @@ export const AddressOutput: React.FC<IAddressOutputProps> = (props) => {
     const checksumAddress = addressUtils.isAddress(address) ? addressUtils.getChecksum(address) : address;
     const displayLabel = label ?? (showCompleteAddress ? checksumAddress : addressUtils.truncateAddress(address));
 
-    const text = <span className={classNames('min-w-0', className)}>{displayLabel}</span>;
+    const text = <span className={classNames('inline-block min-w-0 max-w-full', className)}>{displayLabel}</span>;
 
     const labelElement =
         href == null ? (

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.stories.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.stories.tsx
@@ -70,4 +70,15 @@ export const InteractiveItem: Story = {
     },
 };
 
+/**
+ * Keeps the address label and copy control inside a narrow card.
+ */
+export const LongEnsName: Story = {
+    args: {
+        ensName: 'michiganblockchain.eth',
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        href: '/members/michiganblockchain.eth',
+    },
+};
+
 export default meta;

--- a/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.test.tsx
+++ b/src/modules/components/member/memberDataListItem/memberDataListItemStructure/memberDataListItemStructure.test.tsx
@@ -69,6 +69,18 @@ describe('<MemberDataListItem /> component', () => {
         expect(await screen.findByRole('tooltip')).toHaveTextContent(address);
     });
 
+    it('keeps the copy control available for a long ENS name', () => {
+        render(
+            createTestComponent({
+                ensName: 'michiganblockchain.eth',
+                href: '/members/michiganblockchain.eth',
+            }),
+        );
+
+        expect(screen.getByText('michiganblockchain.eth')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    });
+
     it('renders and formats the delegation count of the member when defined', () => {
         const { rerender } = render(createTestComponent({ delegationCount: 340 }));
         expect(screen.getByRole('heading', { level: 3, name: '340 Delegations' })).toBeInTheDocument();


### PR DESCRIPTION
## Description

Keep long ENS/address labels and their copy controls inside member cards.

The shared `Clipboard` wrapper and `DataList.Item` interactive content now expose shrink boundaries, while `AddressOutput` renders its truncatable label as a constrained inline block. This lets the label ellipsize before the copy control instead of pushing the control outside the card.

## Type of change

- [x] Bug fix

## Verification

- [x] Full Jest suite: 167 suites, 1223 tests passed
- [x] Type-check passed
- [x] Lint check passed
- [x] Storybook build passed
- [x] Package build passed
- [x] Browser smoke check confirmed `michiganblockchain.eth` truncates and keeps Copy inside the card in the fixed-width three-column story.