### PR TITLE
fix(wallet): keep address label hidden below md breakpoint

### DIFF
--- a/.changeset/fix-wallet-responsive-address.md
+++ b/.changeset/fix-wallet-responsive-address.md
@@ -1,0 +1,5 @@
+---
+"@aragon/gov-ui-kit": patch
+---
+
+Restore the Wallet address label at medium and larger breakpoints while keeping small layouts avatar-only.

--- a/src/modules/components/wallet/wallet.tsx
+++ b/src/modules/components/wallet/wallet.tsx
@@ -50,7 +50,7 @@ export const Wallet: React.FC<IWalletProps> = (props) => {
                     id={contentId}
                 >
                     {!user && copy.wallet.connect}
-                    {user && isEnsLoading && <StateSkeletonBar className="hidden md:block" size="lg" width={56} />}
+                    {user && isEnsLoading && <StateSkeletonBar className="block max-md:hidden" size="lg" width={56} />}
                     {user && !isEnsLoading && (
                         <AddressOutput
                             address={user.address}

--- a/src/modules/components/wallet/wallet.tsx
+++ b/src/modules/components/wallet/wallet.tsx
@@ -33,7 +33,7 @@ export const Wallet: React.FC<IWalletProps> = (props) => {
         'flex max-w-48 cursor-pointer items-center gap-3 rounded-full border border-neutral-100 bg-neutral-0 text-neutral-500 transition-all',
         'focus-ring-primary hover:border-neutral-200 active:bg-neutral-50 active:text-neutral-800 disabled:cursor-default',
         { 'px-4 py-2.5': user == null },
-        { 'p-1 xl:pl-4': user != null },
+        { 'p-1 md:pl-4': user != null },
         className,
     );
 
@@ -50,11 +50,11 @@ export const Wallet: React.FC<IWalletProps> = (props) => {
                     id={contentId}
                 >
                     {!user && copy.wallet.connect}
-                    {user && isEnsLoading && <StateSkeletonBar className="hidden xl:block" size="lg" width={56} />}
+                    {user && isEnsLoading && <StateSkeletonBar className="hidden md:block" size="lg" width={56} />}
                     {user && !isEnsLoading && (
                         <AddressOutput
                             address={user.address}
-                            className="hidden truncate xl:inline-flex"
+                            className="truncate max-md:hidden"
                             label={resolvedUserHandle}
                         />
                     )}


### PR DESCRIPTION
## Problem

After #768, the `Wallet` pill rendered its address label at every breakpoint. The small layout is supposed to be avatar-only.

`Wallet` passed `className="hidden md:block truncate"` to `AddressOutput`, and #768 started forwarding that `className` to the component root. `AddressOutput`'s own base `inline-flex` and the incoming `hidden` are both single-class utilities, so `classNames` order does not decide the winner — CSS source order does, and `inline-flex` is emitted after `hidden` in Tailwind's layer. The label stayed visible below `md`, the loading skeleton behaved the same way, and the pill kept its `md` padding at small sizes.

## Change

- `AddressOutput` label: `hidden md:block truncate` → `truncate max-md:hidden`. A `max-*` variant carries a media query, so it wins below `md` regardless of source order and stops fighting the base `inline-flex`.
- `StateSkeletonBar`: `block max-md:hidden`, matching the label's responsive visibility while retaining block dimensions.
- Pill padding: `p-1 md:pl-4` so the icon-only small layout keeps its square padding.

## Verification

- Storybook `Wallet` at 767/768px: label hidden with a 50px pill below `md`; label visible with a ~161px pill at `md` and above.
- `pnpm test -- --runInBand src/modules/components/wallet/wallet.test.tsx` (9 passed), `pnpm lint:check`, `pnpm type-check`, `pnpm build`, `pnpm css:check`.